### PR TITLE
Persist player preferences using bind mount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+data/

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -176,6 +176,13 @@ If Activities are not set up, `!activity` will fail; `!wheel` and `!newwheel` (v
    docker compose -f /home/deploy/mythic-plus-bot/docker-compose.yml ps
    ```
 
+### 4.1 Data Persistence
+
+The bot now stores player preferences (roles) in a `data/` directory inside the repository folder on the Pi (`/home/deploy/mythic-plus-bot/data`).
+- This directory is created automatically by Docker when the container starts.
+- It is ignored by git (via `.gitignore`), so your data survives deployments and `git reset`.
+- You can back up this file manually: `cp /home/deploy/mythic-plus-bot/data/player_preferences.json ~/.backup_prefs.json`.
+
 ## 5. Verification checklist
 
 Run these checks if a deploy fails or you want to validate the setup.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - DISCORD_APPLICATION_ID=${DISCORD_APPLICATION_ID}
       - PREFERENCES_PATH=/data/player_preferences.json
     volumes:
-      - bot-data:/data
+      - ./data:/data
     healthcheck:
       test: ["CMD-SHELL", "grep -aq 'bot.py' /proc/1/cmdline"]
       interval: 10s
@@ -16,6 +16,3 @@ services:
       retries: 3
       start_period: 20s
     restart: unless-stopped
-
-volumes:
-  bot-data:


### PR DESCRIPTION
Switched from using a Docker named volume to a bind mount for storing player preferences. This ensures that the `player_preferences.json` file persists in the `data/` directory on the host machine across container updates and deployments.

---
*PR created automatically by Jules for task [957820197532823968](https://jules.google.com/task/957820197532823968) started by @TytaniumDev*