### PR TITLE
Allow /readycheck to work in text channels

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -156,19 +156,23 @@ def getPlayerList(members) -> list[WoWPlayer]:
     return players
 
 async def launch_role_board(ctx):
-    if not ctx.author.voice or not ctx.author.voice.channel:
-        msg = "❌ You must be in a voice channel to use this command."
+    if not ctx.guild:
+        msg = "❌ This command can only be used in a server."
         if hasattr(ctx, "interaction") and ctx.interaction:
             await ctx.send(msg, ephemeral=True)
         else:
             await ctx.send(msg)
         return
 
-    voice_channel = ctx.author.voice.channel
+    # Determine target channel: Voice channel if available, otherwise current text channel
+    if ctx.author.voice and ctx.author.voice.channel:
+        target_channel = ctx.author.voice.channel
+    else:
+        target_channel = ctx.channel
 
     async def update_board(interaction, board_message):
-        # Re-fetch members from the voice channel to ensure we have the latest state.
-        channel = ctx.guild.get_channel(voice_channel.id)
+        # Re-fetch members from the channel to ensure we have the latest state.
+        channel = ctx.guild.get_channel(target_channel.id)
         if not channel:
              return
 
@@ -179,7 +183,7 @@ async def launch_role_board(ctx):
         await board_message.edit(embed=embed)
 
     # Initial render
-    members = [m for m in voice_channel.members if not m.bot]
+    members = [m for m in target_channel.members if not m.bot]
     players = getPlayerList(members)
     embed = create_role_board_embed(players)
     view = RoleBoardView(update_callback=update_board)

--- a/role_ui.py
+++ b/role_ui.py
@@ -92,7 +92,7 @@ class RoleBoardView(discord.ui.View):
         await interaction.response.send_message(f"Select your roles for **{name}**:", view=view, ephemeral=True)
 
 def create_role_board_embed(players):
-    embed = discord.Embed(title="Mythic+ Role Board", description="Current voice channel roster", color=discord.Color.gold())
+    embed = discord.Embed(title="Mythic+ Role Board", description="Current channel roster", color=discord.Color.gold())
 
     def format_player(p):
         icons = ""

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -7,11 +7,20 @@ from unittest.mock import MagicMock, AsyncMock
 # Add the parent directory to the Python path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from role_ui import RoleSelectionView, RoleButton, RoleBoardView
+from role_ui import RoleSelectionView, RoleButton, RoleBoardView, create_role_board_embed
 from config import ROLE_TANK, ROLE_HEALER
+from models import WoWPlayer
 import discord
 
 class TestUI(unittest.IsolatedAsyncioTestCase):
+    def test_create_role_board_embed_description(self):
+        # Create a dummy list of players (can be empty for this test)
+        players = []
+        embed = create_role_board_embed(players)
+
+        self.assertEqual(embed.title, "Mythic+ Role Board")
+        self.assertEqual(embed.description, "Current channel roster")
+        self.assertEqual(embed.color, discord.Color.gold())
     async def test_role_selection_view_initialization(self):
         initial_roles = [ROLE_TANK, "Brez"]
         # Mocking get_running_loop to avoid "no running event loop" error during View.__init__


### PR DESCRIPTION
This PR updates the `/readycheck` and `/roles` commands to support execution in text channels when the user is not in a voice channel.

Changes:
- **`bot.py`**: Updated `launch_role_board` to use the current text channel as a fallback source for members if the user is not in a voice channel. Added a check to ensure the command is run in a server.
- **`role_ui.py`**: Changed the embed description from "Current voice channel roster" to "Current channel roster".
- **`tests/test_ui.py`**: Added a test case `test_create_role_board_embed_description` to verify the new embed description.

This allows for easier testing of the command and provides functionality when voice chat is not being used.

---
*PR created automatically by Jules for task [9725028497037877263](https://jules.google.com/task/9725028497037877263) started by @TytaniumDev*