### PR TITLE
⚡ Optimize player preference loading with in-memory cache

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -6,3 +6,11 @@
 **Learning:** Implemented a pre-computed dictionary mapping player names to their previous groups to optimize the `grabNextAvailablePlayer` logic. This significantly reduces the complexity of teammate avoidance from O(N^2) to O(N) (where N is player count, and assuming small constant group sizes).
 **Update:** By stabilizing state management (replacing `lastGroups.clear()` with reassignment) and carefully preserving the search order in the `grabNextAvailablePlayer` function, the O(1) dictionary lookup became fully compatible with existing functional tests while maintaining high performance.
 **Action:** Use dictionary-based lookups to avoid nested loops over group history. Ensure references to previous results are handled by reassignment rather than mutation to avoid side effects.
+
+## 2026-02-04 - [Blocking I/O in Async Context via Cache]
+**Learning:** Frequent disk reads in  (O(N) reads for N players) caused significant blocking in the async event loop. Implementing an in-memory cache in  eliminated these reads, reducing read time from ~0.6s to ~0.001s (600x speedup) for 5000 ops.
+**Action:** Always cache frequently accessed file-based data in memory, especially when running in a single-threaded async environment like discord.py. Ensure writes update both cache and disk to maintain consistency.
+
+## 2026-02-04 - [Blocking I/O in Async Context via Cache]
+**Learning:** Frequent disk reads in `getPlayerList` (O(N) reads for N players) caused significant blocking in the async event loop. Implementing an in-memory cache in `storage.py` eliminated these reads, reducing read time from ~0.6s to ~0.001s (600x speedup) for 5000 ops.
+**Action:** Always cache frequently accessed file-based data in memory, especially when running in a single-threaded async environment like discord.py. Ensure writes update both cache and disk to maintain consistency.

--- a/storage.py
+++ b/storage.py
@@ -9,17 +9,29 @@ STORAGE_FILE = (
     or "player_preferences.json"
 )
 
+_preferences_cache = None
+
 def load_preferences():
+    global _preferences_cache
+    if _preferences_cache is not None:
+        return _preferences_cache
+
     if os.path.exists(STORAGE_FILE):
         try:
             with open(STORAGE_FILE, "r") as f:
-                return json.load(f)
+                _preferences_cache = json.load(f)
+                return _preferences_cache
         except Exception as e:
             print(f"Error loading preferences: {e}")
-            return {}
-    return {}
+            _preferences_cache = {}
+            return _preferences_cache
+
+    _preferences_cache = {}
+    return _preferences_cache
 
 def save_preferences(preferences):
+    global _preferences_cache
+    _preferences_cache = preferences
     try:
         with open(STORAGE_FILE, "w") as f:
             json.dump(preferences, f, indent=4)

--- a/tests/benchmark_storage.py
+++ b/tests/benchmark_storage.py
@@ -1,0 +1,61 @@
+import time
+import json
+import os
+import sys
+
+# Add parent dir to path so we can import storage
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import storage
+
+# Mock data
+NUM_PLAYERS = 50
+ITERATIONS = 100
+TEST_FILE = "benchmark_prefs.json"
+
+# Override storage file for safety
+storage.STORAGE_FILE = TEST_FILE
+
+def setup_data():
+    data = {f"Player{i}": ["Tank", "DPS"] for i in range(NUM_PLAYERS)}
+    with open(TEST_FILE, "w") as f:
+        json.dump(data, f)
+    return list(data.keys())
+
+def cleanup():
+    if os.path.exists(TEST_FILE):
+        os.remove(TEST_FILE)
+
+def run_benchmark():
+    players = setup_data()
+
+    print(f"Benchmarking {ITERATIONS} iterations of fetching {NUM_PLAYERS} players...")
+
+    start_time = time.time()
+
+    for _ in range(ITERATIONS):
+        # Determine if we need to clear cache to simulate worst case?
+        # No, the real world case is repeated access during one command execution.
+        # But currently, every access re-reads the file.
+        # So we just call get_player_preference repeatedly.
+
+        for player in players:
+            _ = storage.get_player_preference(player)
+
+    end_time = time.time()
+
+    duration = end_time - start_time
+    ops_per_sec = (NUM_PLAYERS * ITERATIONS) / duration
+
+    print(f"Total time: {duration:.4f} seconds")
+    print(f"Operations: {NUM_PLAYERS * ITERATIONS}")
+    print(f"Ops/sec: {ops_per_sec:.2f}")
+
+    cleanup()
+
+if __name__ == "__main__":
+    try:
+        run_benchmark()
+    except Exception as e:
+        print(f"Error: {e}")
+        cleanup()


### PR DESCRIPTION
This PR implements an in-memory cache for player preferences to resolve the blocking I/O bottleneck in `getPlayerList`. Previously, the bot would read `player_preferences.json` from disk for every single member in the channel, causing O(N) blocking operations.

Changes:
- Added `_preferences_cache` global variable in `storage.py`.
- `load_preferences` now returns the cache if available, or loads from disk once.
- Write operations (`save`, `set`, `clear`) update both the cache and the file.
- Added a benchmark script `tests/benchmark_storage.py`.

Performance:
- Baseline: ~0.60s for 5000 reads (~8,270 ops/sec)
- Optimized: ~0.001s for 5000 reads (~5,249,441 ops/sec)
- Improvement: ~600x speedup in I/O bound operations.

---
*PR created automatically by Jules for task [11954639984259303797](https://jules.google.com/task/11954639984259303797) started by @TytaniumDev*