### PR TITLE
Update bot commands to support slash commands

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -113,7 +113,7 @@ async def test(ctx):
 # !wheel
 # Generates a series of embed messages that shows groups of players split
 # into 5 person teams based on their assigned roles in discord.
-@bot.command()
+@bot.hybrid_command(name="wheel", description="Generates Mythic+ groups based on roles.")
 async def wheel(ctx):
     try:
         await coreWheel(ctx=ctx, debugValue=False)
@@ -200,7 +200,7 @@ async def readycheck(ctx):
     """Alias for /roles. Opens the Mythic+ Role Board."""
     await launch_role_board(ctx)
 
-@bot.command()
+@bot.hybrid_command(name="rolecheck", description="Check saved roles for players in your channel.")
 async def rolecheck(ctx):
     """List saved roles for everyone in the current voice channel (or recent players)."""
     channel = ctx.author.voice.channel if ctx.author.voice else ctx.channel
@@ -231,7 +231,7 @@ async def rolecheck(ctx):
     else:
         await ctx.send(embed=embed)
 
-@bot.command()
+@bot.hybrid_command(name="invite", description="Get an invite link to add this bot to your server.")
 async def invite(ctx):
     """Get the bot invite URL with the configured permissions (for adding the bot to a server)."""
     app_id = bot.application_id or os.getenv("DISCORD_APPLICATION_ID")
@@ -243,7 +243,7 @@ async def invite(ctx):
     url = discord.utils.oauth_url(app_id, scopes=["bot"], permissions=permissions)
     await ctx.send(f"**Add this bot to a server:**\n{url}")
 
-@bot.command()
+@bot.hybrid_command(name="status", description="Displays bot uptime and system status.")
 async def status(ctx):
     """Check the bot's status and uptime."""
     uptime_seconds = int(time.time() - start_time)
@@ -262,7 +262,8 @@ async def status(ctx):
     embed.set_footer(text=f"Server ID: {ctx.guild.id if ctx.guild else 'DM'}")
     await ctx.send(embed=embed)
 
-@bot.command()
+@bot.hybrid_command(name="clearrole", description="Clear saved roles for yourself or a specific character.")
+@discord.app_commands.describe(name="The specific character name to clear (optional).")
 async def clearrole(ctx, name: str = None):
     """Clear your saved roles, or a specific character's roles."""
     if name is None:
@@ -430,7 +431,7 @@ async def coreWheel(ctx, debugValue: bool = None, enhanced: bool = False):
         await _execute_coreWheel(ctx, channel, guild_id, debug, enhanced)
 
 
-@bot.command()
+@bot.hybrid_command(name="newwheel", description="Generates groups with enhanced visuals and sound.")
 async def newwheel(ctx):
     try:
         await coreWheel(ctx=ctx, debugValue=False, enhanced=True)
@@ -440,7 +441,7 @@ async def newwheel(ctx):
         await ctx.send("❌ An unexpected error occurred. Please try again later.")
         print(f"Error in newwheel command: {e}")
 
-@bot.command()
+@bot.hybrid_command(name="activity", description="Starts the spinning wheel activity with an invite link.")
 async def activity(ctx):
     try:
         # Run enhanced wheel


### PR DESCRIPTION
Converted existing prefix commands to hybrid commands to support Discord's slash command interface while maintaining backward compatibility. Added help descriptions for better user experience in the autocomplete menu.

---
*PR created automatically by Jules for task [1186561913955447840](https://jules.google.com/task/1186561913955447840) started by @TytaniumDev*