### PR TITLE
Fix duplicate Jules workflow triggers

### DIFF
--- a/.github/workflows/jules-issue-fix.yml
+++ b/.github/workflows/jules-issue-fix.yml
@@ -5,7 +5,9 @@ on:
 
 jobs:
   dispatch-jules:
-    if: contains(github.event.issue.labels.*.name, 'jules')
+    if: |
+      (github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'jules')) ||
+      (github.event.action == 'labeled' && github.event.label.name == 'jules')
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
This PR fixes a bug where the 'Send Issue to Jules' workflow would run multiple times for the same issue.

**The Problem:**
The workflow was configured to run on `opened` and `labeled` types, with the condition `contains(github.event.issue.labels.*.name, 'jules')`.
When an issue already had the 'jules' label and another label (e.g., 'bug') was added, the `labeled` event would fire. Since the issue *still contained* 'jules', the condition evaluated to true, triggering a duplicate run.

**The Fix:**
I updated the workflow `if` condition to be more specific:
- For `opened` events: It still checks if 'jules' is present.
- For `labeled` events: It now checks if the *specific label being added* (`github.event.label.name`) is 'jules'.

This ensures the workflow runs exactly once when the 'jules' label is introduced, regardless of other labels.

**Verification:**
- Verified that the logic covers the user's use case (bot creating issues with multiple labels, or user adding labels manually).
- Ran existing tests and lint checks to ensure no regressions.

---
*PR created automatically by Jules for task [7761331725308981254](https://jules.google.com/task/7761331725308981254) started by @TytaniumDev*