### PR TITLE
Split CI/CD into reusable workflows for better PR visibility

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,7 @@
-name: CI and Deploy
+name: Deploy
 
 on:
   push:
-    branches:
-      - main
-      - master
-  pull_request:
     branches:
       - main
       - master
@@ -13,41 +9,14 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - name: Install dev dependencies
-        run: python -m pip install -r requirements-dev.txt
-      - name: Ruff (lint)
-        run: ruff check .
-      - name: Ruff (format check)
-        run: ruff format --check .
-      - name: Pyright (type check)
-        run: pyright .
+    uses: ./.github/workflows/lint.yml
 
   test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - name: Install dependencies
-        run: python -m pip install -r requirements.txt
-      - name: Run tests
-        run: python -m unittest discover -s tests -p "test_*.py"
+    uses: ./.github/workflows/test.yml
 
   build-and-push:
     needs: [lint, test]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
     permissions:
       contents: read
       packages: write
@@ -81,7 +50,6 @@ jobs:
   deploy:
     needs: build-and-push
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
     timeout-minutes: 20
     steps:
       - name: Connect to Tailscale

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: Lint
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+  workflow_call:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dev dependencies
+        run: python -m pip install -r requirements-dev.txt
+      - name: Ruff (lint)
+        run: ruff check .
+      - name: Ruff (format check)
+        run: ruff format --check .
+      - name: Pyright (type check)
+        run: pyright .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Test
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+  workflow_call:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: python -m pip install -r requirements.txt
+      - name: Run tests
+        run: python -m unittest discover -s tests -p "test_*.py"


### PR DESCRIPTION
Refactored the CI/CD pipeline by splitting `ci-cd.yml` into `lint.yml`, `test.yml`, and `deploy.yml`. 

*   `lint.yml` and `test.yml` run on Pull Requests and are callable.
*   `deploy.yml` runs on push to `main` or `master`. It first calls the `lint` and `test` workflows to ensure code quality, then proceeds to `build-and-push` and `deploy` jobs.

This separates the "Deploy" check from Pull Requests, reducing confusion, while maintaining safety on the deployment branch.

---
*PR created automatically by Jules for task [10729371803801139516](https://jules.google.com/task/10729371803801139516) started by @TytaniumDev*