### PR TITLE
Prevent duplicate Jules tasks using workflow concurrency

### DIFF
--- a/.github/workflows/jules-issue-fix.yml
+++ b/.github/workflows/jules-issue-fix.yml
@@ -3,6 +3,10 @@ on:
   issues:
     types: [opened, labeled]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
   dispatch-jules:
     if: |


### PR DESCRIPTION
This change addresses an issue where creating a GitHub issue via the Discord bot (or manually with labels) would trigger multiple parallel runs of the Jules fix workflow. By adding `concurrency: group: ... cancel-in-progress: true`, we ensure that overlapping runs for the same issue are debounced, resulting in a single task execution. This preserves the desired behavior of the Discord bot creating labeled issues atomically while fixing the duplicate task creation problem.

---
*PR created automatically by Jules for task [14559556700005912414](https://jules.google.com/task/14559556700005912414) started by @TytaniumDev*