### PR TITLE
Fix duplicate Jules workflow runs

### DIFF
--- a/.github/workflows/jules-issue-fix.yml
+++ b/.github/workflows/jules-issue-fix.yml
@@ -9,6 +9,9 @@ concurrency:
 
 jobs:
   dispatch-jules:
+    # Trigger logic:
+    # 1. Manual creation with label: 'opened' event contains 'jules' in labels list.
+    # 2. Label added later (or via bot): 'labeled' event has 'jules' as the specific label added.
     if: |
       (github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'jules')) ||
       (github.event.action == 'labeled' && github.event.label.name == 'jules')

--- a/core/issues.py
+++ b/core/issues.py
@@ -41,6 +41,36 @@ async def create_github_issue(
                 )
 
 
+async def add_github_issue_labels(issue_number: int, labels: list[str]) -> list[dict]:
+    if (
+        not config.GITHUB_TOKEN
+        or not config.GITHUB_REPO_OWNER
+        or not config.GITHUB_REPO_NAME
+    ):
+        raise GitHubError(
+            "GitHub configuration is missing. Please check your .env file."
+        )
+
+    url = f"https://api.github.com/repos/{config.GITHUB_REPO_OWNER}/{config.GITHUB_REPO_NAME}/issues/{issue_number}/labels"
+    headers = {
+        "Authorization": f"token {config.GITHUB_TOKEN}",
+        "Accept": "application/vnd.github.v3+json",
+    }
+
+    # API expects a list of strings directly
+    data = labels
+
+    async with aiohttp.ClientSession() as session:
+        async with session.post(url, headers=headers, json=data) as response:
+            if response.status == 200:
+                return await response.json()
+            else:
+                error_text = await response.text()
+                raise GitHubError(
+                    f"Failed to add labels: {response.status} - {error_text}"
+                )
+
+
 class GitHubIssueModal(ui.Modal):
     def __init__(self, issue_type: str) -> None:
         self.issue_type = issue_type
@@ -94,12 +124,19 @@ class GitHubIssueModal(ui.Modal):
             )
             body += f"\n**{section_title}:**\n{extra}\n"
 
-        # Add Jules label for automation
-        labels = ["bug"] if self.issue_type == "bug" else ["enhancement"]
-        labels.append("jules")
+        # Create issue first WITHOUT Jules label to prevent double-triggering
+        # (Opened event triggers, then Labeled event triggers)
+        initial_labels = ["bug"] if self.issue_type == "bug" else ["enhancement"]
 
         try:
-            issue = await create_github_issue(title, body, labels)
+            # Step 1: Create Issue
+            issue = await create_github_issue(title, body, initial_labels)
+            issue_number = int(issue["number"])  # Ensure integer
+
+            # Step 2: Add 'jules' label separately
+            # This ensures we rely on the 'labeled' event or clear separation
+            await add_github_issue_labels(issue_number, ["jules"])
+
             await interaction.followup.send(
                 f"✅ Issue created successfully: {issue['html_url']}", ephemeral=True
             )

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, patch
 
 import discord
 
-from core.issues import GitHubError, GitHubIssueModal, create_github_issue
+from core.issues import GitHubError, GitHubIssueModal, create_github_issue, add_github_issue_labels
 
 
 class TestIssues(unittest.IsolatedAsyncioTestCase):
@@ -24,6 +24,22 @@ class TestIssues(unittest.IsolatedAsyncioTestCase):
 
                 result = await create_github_issue("Title", "Body", ["bug"])
                 self.assertEqual(result["html_url"], "http://github.com/issue/1")
+
+    async def test_add_github_issue_labels_success(self):
+        # Mock config values
+        with (
+            patch("core.config.GITHUB_TOKEN", "fake_token"),
+            patch("core.config.GITHUB_REPO_OWNER", "owner"),
+            patch("core.config.GITHUB_REPO_NAME", "repo"),
+        ):
+            with patch("aiohttp.ClientSession.post") as mock_post:
+                mock_response = AsyncMock()
+                mock_response.status = 200
+                mock_response.json.return_value = [{"name": "jules"}]
+                mock_post.return_value.__aenter__.return_value = mock_response
+
+                result = await add_github_issue_labels(1, ["jules"])
+                self.assertEqual(result[0]["name"], "jules")
 
     async def test_create_github_issue_failure(self):
         with (
@@ -56,11 +72,13 @@ class TestIssues(unittest.IsolatedAsyncioTestCase):
         modal.description._value = "Bug Description"  # pyright: ignore[reportPrivateUsage]
         modal.extra_info._value = "Steps"  # pyright: ignore[reportPrivateUsage]
 
-        # Mock config and create_github_issue
-        with patch(
-            "core.issues.create_github_issue", new_callable=AsyncMock
-        ) as mock_create:
-            mock_create.return_value = {"html_url": "http://url"}
+        # Mock config and create_github_issue and add_github_issue_labels
+        with (
+            patch("core.issues.create_github_issue", new_callable=AsyncMock) as mock_create,
+            patch("core.issues.add_github_issue_labels", new_callable=AsyncMock) as mock_add_labels
+        ):
+            mock_create.return_value = {"html_url": "http://url", "number": 123}
+            mock_add_labels.return_value = [{"name": "jules"}]
 
             await modal.on_submit(mock_interaction)
 
@@ -71,7 +89,11 @@ class TestIssues(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(title, "Bug Title")
             self.assertIn("Bug Description", body)
             self.assertIn("Steps", body)
-            self.assertEqual(labels, ["bug", "jules"])
+            # Should NOT contain 'jules' at creation time
+            self.assertEqual(labels, ["bug"])
+
+            # Verify 'jules' was added in the second step
+            mock_add_labels.assert_called_once_with(123, ["jules"])
 
             mock_interaction.followup.send.assert_called_with(
                 "✅ Issue created successfully: http://url", ephemeral=True


### PR DESCRIPTION
Implemented a "Split Creation Strategy" to prevent the Jules GitHub Actions workflow from running multiple times for a single issue.
- Modified `core/issues.py` to create issues *without* the 'jules' label first, then add it separately.
- Added `add_github_issue_labels` helper function.
- Verified the fix with updated unit tests in `tests/test_issues.py`.
- Documented the trigger logic in `.github/workflows/jules-issue-fix.yml`.

---
*PR created automatically by Jules for task [3761951411160485489](https://jules.google.com/task/3761951411160485489) started by @TytaniumDev*