### PR TITLE
fix: prevent deploy secret leak and add safeguards

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,6 +91,15 @@ jobs:
           echo "Testing SSH connection to ${{ secrets.PI_HOST }}..."
           ssh -v -i ~/.ssh/deploy_key -o ConnectTimeout=30 -o StrictHostKeyChecking=accept-new \
             ${{ secrets.PI_USER }}@${{ secrets.PI_HOST }} "echo 'SSH connection successful!'"
+      - name: Encode Firebase credentials
+        id: firebase_b64
+        run: |
+          # Encode as single-line base64 so multiline JSON is not inlined in the deploy script
+          # (inlining would break bash and can leak secrets in error messages)
+          firebase_b64=$(echo "${{ secrets.FIREBASE_CREDENTIALS_JSON }}" | base64 -w0)
+          echo "firebase_b64<<OUTPUT_EOF" >> $GITHUB_OUTPUT
+          echo "$firebase_b64" >> $GITHUB_OUTPUT
+          echo "OUTPUT_EOF" >> $GITHUB_OUTPUT
       - name: Deploy to Raspberry Pi
         run: |
           ssh -i ~/.ssh/deploy_key -o ConnectTimeout=30 \
@@ -107,13 +116,14 @@ jobs:
             echo "Updating repo..."
             git fetch origin && git reset --hard origin/${{ github.ref_name }}
 
-            # Set environment for docker compose
+            # Set environment for docker compose (Firebase passed as base64 to avoid multiline/leak)
             export IMAGE_NAME=$(echo ghcr.io/${{ github.repository }} | tr '[:upper:]' '[:lower:]')
             export IMAGE_TAG=${{ github.sha }}
             export BOT_TOKEN="${{ secrets.BOT_TOKEN }}"
             export DISCORD_APPLICATION_ID="${{ secrets.DISCORD_APPLICATION_ID }}"
             export GITHUB_TOKEN="${{ secrets.GH_ISSUE_TOKEN }}"
-            export FIREBASE_CREDENTIALS_JSON="${{ secrets.FIREBASE_CREDENTIALS_JSON }}"
+            FIREBASE_B64='${{ steps.firebase_b64.outputs.firebase_b64 }}'
+            export FIREBASE_CREDENTIALS_JSON="\$(echo "\$FIREBASE_B64" | base64 -d)"
 
             # Deploy
             echo "Pulling image..."

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,0 +1,28 @@
+name: Workflow Lint
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+    paths:
+      - ".github/workflows/**"
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - ".github/workflows/**"
+
+jobs:
+  workflow-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Check workflow secrets
+        run: python3 scripts/check-workflow-secrets.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,17 @@ To maintain consistency and prevent CI failures, the following rules are mandato
 - All bot commands, events, and API interactions must be implemented using `async/await` syntax.
 - Maintain proper error handling for Discord API interactions to ensure bot stability.
 
+### 4. Secrets in Workflows (GitHub Actions)
+
+When adding or modifying `.github/workflows/*.yml`, follow these rules to prevent secret leaks:
+
+- **Never inline multi-line secrets** (e.g. JSON keys, PEM keys) in `run:` scripts or heredocs. Multi-line values break bash and can be echoed in error messages, leaking secrets in CI logs.
+- **Safe pattern for multi-line secrets** passed to remote scripts (e.g. SSH heredocs): encode on the runner (e.g. base64), pass a single-line value via step output or env, decode on the remote.
+- **Never echo or log** variables that may contain secrets: do not use `set -x` in steps that use secrets; do not `echo $SECRET_VAR`.
+- **Prefer writing secrets to files** on the runner when possible (e.g. `echo "${{ secrets.PI_SSH_KEY }}" > file`), and only pass single-line or base64-encoded values into remote heredocs.
+
+See `scripts/check-workflow-secrets.py` and the workflow-lint job for automated checks.
+
 ## Task Execution Workflow
 1. **Analyze:** Understand the task requirements and review the relevant codebase.
 2. **Environment:** Ensure the environment is set up and dependencies are installed (e.g., `pip install -r requirements.txt`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,8 @@ Required for bot: `BOT_TOKEN`, `DISCORD_APPLICATION_ID`
 Required for Firebase features: `FIREBASE_CREDENTIALS_JSON`
 Optional: `DEVELOPER_ID`, `ACTIVITY_URL`, role name overrides (see `core/config.py`)
 
+When touching GitHub Actions workflows: read the **Secrets in workflows** section in [AGENTS.md](AGENTS.md). Never inline multi-line secrets (JSON, PEM) in heredocs; use base64 encode on the runner and decode on the remote. The workflow-lint job enforces this.
+
 ## Code Style
 
 - Ruff enforces formatting and linting (see `pyproject.toml` for rules)

--- a/scripts/check-workflow-secrets.py
+++ b/scripts/check-workflow-secrets.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""
+Check GitHub Actions workflow files for unsafe inline of multi-line secrets in heredocs.
+
+Multi-line secrets (JSON, PEM keys) must never be inlined in run scripts or heredocs;
+they break bash and can leak in error messages. Use base64 encode on the runner and
+decode on the remote instead.
+
+Usage: python scripts/check-workflow-secrets.py [workflow_files...]
+If no files given, checks .github/workflows/*.yml
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# Secrets known to be multi-line (JSON, PEM). Inlining these in heredocs is forbidden.
+MULTILINE_SECRET_NAMES = frozenset({"FIREBASE_CREDENTIALS_JSON", "PI_SSH_KEY"})
+
+# Pattern for any secrets.X in workflow expressions (used inside heredocs).
+SECRET_INLINE_PATTERN = re.compile(r"\$\{\{\s*secrets\.([A-Za-z0-9_]+)\s*\}\}")
+
+
+def get_workflow_files(paths: list[str] | None) -> list[Path]:
+    """Resolve paths to workflow YAML files."""
+    if paths:
+        return [Path(p) for p in paths if Path(p).suffix in (".yml", ".yaml")]
+    workflows_dir = Path(".github/workflows")
+    if not workflows_dir.exists():
+        return []
+    return sorted(workflows_dir.glob("*.yml")) + sorted(workflows_dir.glob("*.yaml"))
+
+
+def is_multiline_secret(secret_name: str) -> bool:
+    """True if this secret is known or likely to be multi-line."""
+    if secret_name in MULTILINE_SECRET_NAMES:
+        return True
+    if "_CREDENTIALS" in secret_name or secret_name.endswith("_KEY"):
+        return True
+    return False
+
+
+def check_file(file_path: Path) -> list[str]:
+    """Check a single workflow file. Returns list of error messages."""
+    errors: list[str] = []
+    content = file_path.read_text()
+    lines = content.splitlines()
+
+    # Find all heredocs in the file (run blocks with << DELIMITER)
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        match = re.search(r"<<\s*([A-Za-z0-9_]+)\s*$", line)
+        if match:
+            delim = match.group(1)
+            heredoc_start = i + 1
+            i += 1
+            body_lines: list[str] = []
+            while i < len(lines):
+                if re.match(rf"^\s*{re.escape(delim)}\s*$", lines[i]):
+                    break
+                body_lines.append(lines[i])
+                i += 1
+            body = "\n".join(body_lines)
+            for m in SECRET_INLINE_PATTERN.finditer(body):
+                secret_name = m.group(1)
+                if is_multiline_secret(secret_name):
+                    line_offset = body[: m.start()].count("\n")
+                    file_line = heredoc_start + line_offset
+                    errors.append(
+                        f"{file_path}:{file_line}: "
+                        f"Multi-line secret '{secret_name}' must not be inlined in heredoc. "
+                        "Use base64 encode on the runner and decode on the remote (see AGENTS.md)."
+                    )
+        i += 1
+
+    return errors
+
+
+def main() -> int:
+    paths = sys.argv[1:] or None
+    files = get_workflow_files(paths)
+    if not files:
+        print("No workflow files to check.", file=sys.stderr)
+        return 0
+
+    all_errors: list[str] = []
+    for f in files:
+        all_errors.extend(check_file(f))
+
+    if all_errors:
+        for e in all_errors:
+            print(e)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Fixes the deploy workflow failure and secret leak caused by inlining multi-line `FIREBASE_CREDENTIALS_JSON` in an SSH heredoc, and adds documentation and CI checks to prevent recurrence.

## Problem

- **Deploy failure**: `FIREBASE_CREDENTIALS_JSON` (multi-line JSON) was inlined in the deploy heredoc as `export FIREBASE_CREDENTIALS_JSON="${{ secrets.FIREBASE_CREDENTIALS_JSON }}"`. Newlines in the JSON broke bash ("not a valid identifier") and the error message printed the line, **leaking the private key and Firebase credentials** in GitHub Actions logs.
- **Root cause**: Multi-line secrets must never be inlined in `run:` scripts or heredocs; they can break scripts and leak in error output.

## Changes

### 1. Deploy workflow fix (`.github/workflows/deploy.yml`)

- **Encode step**: New "Encode Firebase credentials" step encodes `FIREBASE_CREDENTIALS_JSON` as base64 on the runner and writes it to a step output (delimiter format to avoid escaping issues).
- **Deploy step**: Heredoc no longer inlines the raw JSON. Instead it passes `FIREBASE_B64='...'` (single-line) and runs `export FIREBASE_CREDENTIALS_JSON="$(echo "$FIREBASE_B64" | base64 -d)"` on the Pi.
- Result: Script remains valid, raw key never appears in script source or error messages.

### 2. Workflow secret lint (broader CI check)

- **`scripts/check-workflow-secrets.py`**: Scans workflow YAML for heredocs and fails if known multi-line secrets (`FIREBASE_CREDENTIALS_JSON`, `PI_SSH_KEY`, or names matching `*_KEY` / `*_CREDENTIALS*`) are inlined as `${{ secrets.X }}` inside them.
- **`.github/workflows/workflow-lint.yml`**: Runs on PR/push when `.github/workflows/**` changes and executes the check.

### 3. Documentation

- **AGENTS.md**: Added section "4. Secrets in Workflows (GitHub Actions)" with rules on never inlining multi-line secrets, using base64 for remote scripts, and not echoing variables that may contain secrets.
- **CLAUDE.md**: Added reference to the policy under Environment Variables.

## Follow-up (manual)

Leaked credentials must be rotated:

- **Firebase**: GCP Console → Service Accounts → delete old key → create new JSON key → update `FIREBASE_CREDENTIALS_JSON` in repo Secrets.
- **PI_SSH_KEY**: Generate new key pair, add pubkey to Pi `authorized_keys`, update secret. See the plan for step-by-step instructions.

Made with [Cursor](https://cursor.com)