### PR TITLE
fix: add missing build script for Deploy Activity to Pages

### DIFF
--- a/activity/package.json
+++ b/activity/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "script.js",
   "scripts": {
+    "build": "vite build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],


### PR DESCRIPTION
## Problem
The **Deploy Activity to Pages** workflow was failing at the "Build Activity" step because it runs `npm run build` in the `activity` directory, but `activity/package.json` had no `build` script defined (only `test`). That caused `npm run build` to exit with code 1.

## Solution
Add a `build` script to `activity/package.json` that runs `vite build`, matching what the workflow expects.

## Verification
- `npm ci && npm run build` in `activity/` completes successfully and produces `activity/dist` output.

Made with [Cursor](https://cursor.com)