### PR TITLE
feat: add /version command with Git SHA and commit link

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,8 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            GIT_SHA=${{ github.sha }}
           tags: |
             ${{ env.IMAGE_NAME }}:latest
             ${{ env.IMAGE_NAME }}:${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /app
 
+ARG GIT_SHA=
+ENV GIT_SHA=${GIT_SHA}
+
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -6,7 +6,13 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-from core.config import BOT_INVITE_PERMISSIONS, DISCORD_APPLICATION_ID
+from core.config import (
+    BOT_INVITE_PERMISSIONS,
+    DISCORD_APPLICATION_ID,
+    GIT_SHA,
+    GITHUB_REPO_NAME,
+    GITHUB_REPO_OWNER,
+)
 from core.issues import GitHubIssueModal
 
 
@@ -33,6 +39,22 @@ class General(commands.Cog):
     async def feature_request(self, interaction: discord.Interaction):
         """Request a new feature for the bot."""
         await interaction.response.send_modal(GitHubIssueModal(issue_type="feature"))
+
+    @app_commands.command(
+        name="version",
+        description="Show the bot version and link to the source commit.",
+    )
+    async def version(self, interaction: discord.Interaction) -> None:
+        """Show the bot version and link to the source commit."""
+        if GIT_SHA and len(GIT_SHA) >= 7:
+            short_sha = GIT_SHA[:7]
+            commit_url = f"https://github.com/{GITHUB_REPO_OWNER}/{GITHUB_REPO_NAME}/commit/{GIT_SHA}"
+            value = f"[`{short_sha}`]({commit_url})"
+        else:
+            value = "unknown"
+        embed = discord.Embed(title="Bot Version", color=discord.Color.blue())
+        embed.add_field(name="Commit", value=value, inline=False)
+        await interaction.response.send_message(embed=embed)
 
     @commands.command()
     async def invite(self, ctx: commands.Context[commands.Bot]) -> None:

--- a/core/config.py
+++ b/core/config.py
@@ -41,6 +41,9 @@ GITHUB_TOKEN = _github_token.strip() if _github_token else None
 GITHUB_REPO_OWNER = os.getenv("GITHUB_REPO_OWNER", "TytaniumDev").strip()
 GITHUB_REPO_NAME = os.getenv("GITHUB_REPO_NAME", "MythicPlusDiscordBot").strip()
 
+# Container version (commit SHA baked in at build time)
+GIT_SHA = os.getenv("GIT_SHA", "").strip() or None
+
 # Activity Link
 ACTIVITY_URL = os.getenv(
     "ACTIVITY_URL", "https://tytaniumdev.github.io/MythicPlusDiscordBot/"

--- a/tests/test_general_cog.py
+++ b/tests/test_general_cog.py
@@ -13,6 +13,51 @@ from cogs.general import General  # noqa: E402, I001
 
 
 class TestGeneralCog(unittest.IsolatedAsyncioTestCase):
+    async def test_version_command_with_sha(self):
+        """When GIT_SHA is set, embed shows short SHA and commit link."""
+        with patch("cogs.general.GIT_SHA", "abc123456789"):
+            with patch("cogs.general.GITHUB_REPO_OWNER", "Owner"):
+                with patch("cogs.general.GITHUB_REPO_NAME", "Repo"):
+                    bot = MagicMock()
+                    cog = General(bot)
+                    interaction = AsyncMock(spec=discord.Interaction)
+                    interaction.response.send_message = AsyncMock()
+
+                    await cast(Any, General.version.callback)(cog, interaction)
+
+                    interaction.response.send_message.assert_called_once()
+                    args, kwargs = interaction.response.send_message.call_args
+                    embed = kwargs.get("embed") or (args[0] if args else None)
+                    self.assertIsInstance(embed, discord.Embed)
+                    assert embed is not None
+                    self.assertEqual(embed.title, "Bot Version")
+                    fields = {f.name: f.value for f in embed.fields}
+                    self.assertIn("Commit", fields)
+                    self.assertIn("abc1234", fields["Commit"])
+                    self.assertIn(
+                        "https://github.com/Owner/Repo/commit/abc123456789",
+                        fields["Commit"],
+                    )
+
+    async def test_version_command_without_sha(self):
+        """When GIT_SHA is unset, embed shows 'unknown'."""
+        with patch("cogs.general.GIT_SHA", None):
+            bot = MagicMock()
+            cog = General(bot)
+            interaction = AsyncMock(spec=discord.Interaction)
+            interaction.response.send_message = AsyncMock()
+
+            await cast(Any, General.version.callback)(cog, interaction)
+
+            interaction.response.send_message.assert_called_once()
+            args, kwargs = interaction.response.send_message.call_args
+            embed = kwargs.get("embed") or (args[0] if args else None)
+            self.assertIsInstance(embed, discord.Embed)
+            assert embed is not None
+            self.assertEqual(embed.title, "Bot Version")
+            fields = {f.name: f.value for f in embed.fields}
+            self.assertEqual(fields["Commit"], "unknown")
+
     async def test_status_command(self):
         # Arrange
         bot = MagicMock()


### PR DESCRIPTION
Adds a `/version` slash command so users can see which commit the running container was built from, with a clickable link to that commit on GitHub.

**Changes:**
- **Dockerfile:** `ARG GIT_SHA` and `ENV GIT_SHA` so the image knows the commit at build time
- **deploy.yml:** Pass `GIT_SHA=${{ github.sha }}` as a build arg in the build-and-push job
- **core/config.py:** `GIT_SHA` from env (default `None`) for runtime
- **cogs/general.py:** New `/version` slash command; embed shows short SHA (7 chars) and link to `https://github.com/{owner}/{repo}/commit/{sha}`, or "unknown" when not set (e.g. local dev)
- **tests:** `test_version_command_with_sha` and `test_version_command_without_sha` in `test_general_cog.py`

`./scripts/verify.sh` passes (ruff, pyright, unit tests).

Made with [Cursor](https://cursor.com)