### PR TITLE
fix: prevent secrets from leaking into logs (bug-report safe)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,14 @@ When adding or modifying `.github/workflows/*.yml`, follow these rules to preven
 
 See `scripts/check-workflow-secrets.py` and the workflow-lint job for automated checks.
 
+### 5. Logging and Secrets
+
+Log output may be included in bug reports (e.g. "Recent Logs" in GitHub issues). To avoid leaking secrets:
+
+- **Never log** `BOT_TOKEN`, `GITHUB_TOKEN`, `FIREBASE_CREDENTIALS_JSON`, or any env that could be secret.
+- **When logging exceptions from external APIs** (GitHub, Firebase, etc.), log only the exception type or HTTP status, not the full message or response body.
+- Assume all log output is effectively public when users attach logs to bug reports.
+
 ## Task Execution Workflow
 1. **Analyze:** Understand the task requirements and review the relevant codebase.
 2. **Environment:** Ensure the environment is set up and dependencies are installed (e.g., `pip install -r requirements.txt`).

--- a/bot.py
+++ b/bot.py
@@ -222,4 +222,5 @@ if __name__ == "__main__":
     except discord.LoginFailure:
         logger.error("❌ Failed to login. Please check your BOT_TOKEN.")
     except Exception as e:
-        logger.fatal("❌ Fatal error starting bot: %s", e)
+        # Log exception type only; message may contain request/response data.
+        logger.fatal("❌ Fatal error starting bot: %s", type(e).__name__)

--- a/core/firebase_service.py
+++ b/core/firebase_service.py
@@ -61,7 +61,8 @@ class FirebaseService:
             self.db = firestore.client()
             logger.info("Firebase initialized successfully.")
         except Exception as e:
-            logger.error("Failed to initialize Firebase: %s", e)
+            # Log type only; exception message may contain credential/project hints.
+            logger.error("Failed to initialize Firebase: %s", type(e).__name__)
             self.db = None
 
     def is_available(self) -> bool:

--- a/core/issues.py
+++ b/core/issues.py
@@ -30,7 +30,8 @@ async def _get_recent_logs() -> str | None:
 
             return await asyncio.to_thread(read_last_logs)
         except Exception as e:
-            logger.error("Failed to read logs: %s", e)
+            # Log type only to avoid leaking file paths into logs (bug-report safe).
+            logger.error("Failed to read logs: %s", type(e).__name__)
     return None
 
 
@@ -58,10 +59,9 @@ async def create_github_issue(
             if response.status == 201:
                 return await response.json()
             else:
-                error_text = await response.text()
-                raise GitHubError(
-                    f"Failed to create issue: {response.status} - {error_text}"
-                )
+                # Do not include response body in exception message; it may leak
+                # credentials or repo info into logs (e.g. when included in bug reports).
+                raise GitHubError(f"Failed to create issue: HTTP {response.status}")
 
 
 class GitHubIssueModal(ui.Modal):

--- a/core/storage.py
+++ b/core/storage.py
@@ -39,7 +39,8 @@ def load_preferences() -> dict[str, list[str]]:
                     _preferences_cache = cast(dict[str, list[str]], raw)
                     return _preferences_cache.copy()
             except Exception as e:
-                logger.error("Error loading preferences: %s", e)
+                # Log type only to avoid leaking path or file content into logs.
+                logger.error("Error loading preferences: %s", type(e).__name__)
                 _preferences_cache = {}
                 return _preferences_cache.copy()
 
@@ -56,7 +57,8 @@ def save_preferences(preferences: dict[str, list[str]]) -> None:
         with open(STORAGE_FILE, "w") as f:
             json.dump(preferences, f, indent=4)
     except Exception as e:
-        logger.error("Error saving preferences: %s", e)
+        # Log type only to avoid leaking path or file content into logs.
+        logger.error("Error saving preferences: %s", type(e).__name__)
 
 
 def get_player_preference(player_name: str) -> list[str] | None:


### PR DESCRIPTION
## Summary
Logs can be included in bug reports (e.g. "Recent Logs" in GitHub issues). This PR ensures we never log secrets or API response bodies so logs are safe to share.

## Changes
- **GitHub:** `GitHubError` now includes only HTTP status (e.g. `Failed to create issue: HTTP 403`), not the API response body, so credentials/repo hints never reach logs.
- **Firebase init:** Log only exception type (e.g. `CertificateError`), not the full message (which may contain credential/project hints).
- **Storage load/save:** Log only exception type to avoid leaking file paths or content.
- **Issues (read logs):** Log only exception type when failing to read the log file.
- **Bot startup:** Log only exception type for the fatal error after `bot.run()` to avoid request/response data in logs.
- **AGENTS.md:** New "Logging and Secrets" subsection: never log secrets; for external API exceptions log only type/status; assume logs may be shared in bug reports.

## Note
The `Logged in as Wheelson#1390 (ID: …)` line is **safe** — bot username and numeric ID are public identifiers, not secrets.

Made with [Cursor](https://cursor.com)