### PR TITLE
Add Claude settings with git and gh command permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git *)",
+      "Bash(gh *)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
Added a new `.claude/settings.json` configuration file to define permissions for Claude tool usage within this repository.

## Key Changes
- Created `.claude/settings.json` with a permissions configuration
- Configured allow-list for Bash commands:
  - `Bash(git *)` - permits all git commands
  - `Bash(gh *)` - permits all GitHub CLI commands

## Implementation Details
This settings file establishes a security boundary by explicitly allowing only git and GitHub CLI operations while restricting other bash commands. This enables Claude to safely interact with version control and GitHub workflows without broader shell access.

https://claude.ai/code/session_01QbQTo7QLC4rGuhEVZqqnGg