### PR TITLE
Simplify CI workflow by removing lint and test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,6 @@ on:
   workflow_call:
 
 jobs:
-  lint:
-    name: CI
-    uses: TytaniumDev/.github/.github/workflows/lint.yml@main
-
   build:
     name: CI
     uses: TytaniumDev/.github/.github/workflows/build.yml@main
-
-  test:
-    name: CI
-    uses: TytaniumDev/.github/.github/workflows/test.yml@main


### PR DESCRIPTION
## Summary
Streamlined the CI workflow by removing the separate lint and test job calls, keeping only the build job.

## Changes
- Removed the `lint` job that called the shared lint workflow
- Removed the `test` job that called the shared test workflow
- Retained the `build` job as the sole CI workflow step

## Details
This change consolidates the CI pipeline to run only the build workflow. The lint and test steps are no longer executed as separate workflow jobs in this pipeline. This may indicate that linting and testing functionality has been integrated into the build process or is being handled elsewhere.

https://claude.ai/code/session_01HwJJECbkuD93hjBw39ozhE