### PR TITLE
feat: add browser history routing to activity frontend

### DIFF
--- a/activity/src/main.ts
+++ b/activity/src/main.ts
@@ -75,6 +75,22 @@ let wheelDps1: Wheel | null = null;
 let wheelDps2: Wheel | null = null;
 let wheelDps3: Wheel | null = null;
 
+// ── Routing ──────────────────────────────────────────────────
+type ViewName = 'home' | 'channels' | 'lobby' | 'wheels' | 'results';
+
+const VIEW_TO_ROUTE: Record<ViewName, string> = {
+  home: '#/', channels: '#/channels', lobby: '#/lobby',
+  wheels: '#/wheels', results: '#/results',
+};
+const ROUTE_TO_VIEW: Record<string, ViewName> = {
+  '#/': 'home', '#/channels': 'channels', '#/lobby': 'lobby',
+  '#/wheels': 'wheels', '#/results': 'results',
+};
+
+let currentView: ViewName = 'home';
+let isNavigatingFromPopstate = false;
+let isFirstView = true;
+
 // ── State ────────────────────────────────────────────────────
 let currentSessionId: string | null = null;
 let currentSessionData: Session | null = null;
@@ -262,6 +278,80 @@ async function init() {
     await updateDoc(docRef, { announceResults: announceCheckbox.checked });
   });
 
+  // Browser back/forward navigation
+  window.addEventListener('popstate', (e) => {
+    const hash = location.hash || '#/';
+    const targetView = ROUTE_TO_VIEW[hash];
+    if (!targetView || targetView === currentView) return;
+
+    isNavigatingFromPopstate = true;
+
+    if (currentView === 'channels' && targetView === 'home') {
+      // Back from channels to home: unsubscribe and show demo controls
+      if (sessionUnsubscribe) {
+        sessionUnsubscribe();
+        sessionUnsubscribe = null;
+      }
+      showView('home');
+      renderRecentGuilds();
+      demoControls.classList.remove('hidden');
+    } else if (currentView === 'lobby' && targetView === 'channels') {
+      // Back from lobby to channels: re-render channel picker
+      showView('channels');
+      if (currentSessionData?.voiceChannels) {
+        renderChannelPicker(currentSessionData.voiceChannels);
+      }
+    } else if (currentView === 'wheels' && targetView === 'lobby') {
+      // Back from wheels to lobby: cancel spin and restore lobby
+      resetSpinState();
+      showView('lobby');
+      if (currentSessionData?.players) {
+        renderLobby(currentSessionData.players);
+        announceCheckbox.checked = currentSessionData.announceResults !== false;
+      }
+      // Write status back to lobby
+      if (isDemoMode && currentSessionData) {
+        currentSessionData = { ...currentSessionData, status: 'lobby', groups: [] } as Session;
+      } else if (currentSessionId) {
+        const docRef = doc(db, 'sessions', currentSessionId);
+        updateDoc(docRef, { status: 'lobby', groups: [] });
+      }
+    } else if (currentView === 'results' && targetView === 'lobby') {
+      // Back from results: intercept and redirect to channels for a new round
+      history.replaceState({ view: 'channels' }, '', VIEW_TO_ROUTE.channels);
+      resetSpinState();
+      showView('channels');
+      // Clear selection so user picks a channel again
+      if (isDemoMode && currentSessionData) {
+        currentSessionData = {
+          ...currentSessionData,
+          status: 'lobby',
+          selectedChannelId: null,
+          groups: [],
+          players: [],
+        } as Session;
+        renderChannelPicker(currentSessionData.voiceChannels || []);
+      } else if (currentSessionId) {
+        const docRef = doc(db, 'sessions', currentSessionId);
+        updateDoc(docRef, {
+          status: 'lobby',
+          selectedChannelId: null,
+          groups: [],
+          players: [],
+        });
+        if (currentSessionData?.voiceChannels) {
+          renderChannelPicker(currentSessionData.voiceChannels);
+        }
+      }
+    } else {
+      // Fallback: just show the target view
+      const stateView = (e.state as { view?: ViewName } | null)?.view;
+      showView(stateView ?? targetView);
+    }
+
+    isNavigatingFromPopstate = false;
+  });
+
   // Check for injected mock data (testing)
   const dataParam = urlParams.get('data');
   if (dataParam) {
@@ -383,6 +473,23 @@ function showView(view: 'home' | 'channels' | 'lobby' | 'wheels' | 'results') {
     case 'results':
       viewResults.classList.remove('hidden');
       break;
+  }
+
+  // Update hash-based routing
+  currentView = view;
+  if (!isNavigatingFromPopstate) {
+    const route = VIEW_TO_ROUTE[view];
+    if (isFirstView) {
+      // Replace initial blank entry so back doesn't go to an empty page
+      history.replaceState({ view }, '', route);
+      isFirstView = false;
+    } else if (view === 'results') {
+      // Replace #/wheels so back from results skips the wheels view
+      history.replaceState({ view }, '', route);
+    } else if (location.hash !== route) {
+      // Guard against duplicate entries from repeated Firestore updates
+      history.pushState({ view }, '', route);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Add hash-based routing (`#/`, `#/channels`, `#/lobby`, `#/wheels`, `#/results`) to the activity frontend so the browser back button works correctly through the flow
- Uses `replaceState` for the results view so pressing back skips the wheels animation and goes to channels
- `popstate` handler manages view-specific teardown on back navigation (cancel spins, unsubscribe sessions, reset state)

## Test plan
- [x] `npm run typecheck` passes
- [x] All 65 Playwright tests pass (no screenshot changes — hash doesn't appear in page content)
- [ ] Manual: navigate full flow home → channels → lobby → wheels → results, press back at each step
- [ ] Manual: verify back from results goes to channels (not wheels)
- [ ] Manual: test demo mode with same back-button flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)