### PR TITLE
fix: skip Claude code review when PR is already approved

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,13 +24,17 @@ jobs:
         id: check
         env:
           GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          if [[ "${{ github.event_name }}" != "pull_request" || "${{ github.event.action }}" != "synchronize" ]]; then
+          if [[ "$EVENT_NAME" != "pull_request" || "$EVENT_ACTION" != "synchronize" ]]; then
             echo "should_review=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           # Check if Claude has already approved this PR
-          approved=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews \
+          approved=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
             --jq '[.[] | select(.user.login == "claude[bot]" and .state == "APPROVED")] | length')
           if [[ "$approved" -gt 0 ]]; then
             echo "Claude has already approved this PR, skipping review"


### PR DESCRIPTION
## Summary
- Adds a `check-approval` job that queries the GitHub API for existing Claude approvals before running the review
- On `synchronize` events (new pushes), if Claude has already approved the PR, the review is skipped to prevent duplicate approvals
- Non-synchronize triggers (opened, reopened, comments) always run the review
- If Claude previously requested changes, a new push will still trigger a re-review

Fixes the issue seen in #155 where Claude kept re-approving on every push.

## Test plan
- [ ] Open a new PR → Claude review should run
- [ ] Push a commit after Claude approves → review should be skipped
- [ ] Push a commit after Claude requests changes → review should re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)