### PR TITLE
fix: add permissions to automerge-label workflow

### DIFF
--- a/.github/workflows/automerge-label.yml
+++ b/.github/workflows/automerge-label.yml
@@ -4,6 +4,11 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+
 jobs:
   add-label:
     if: >-


### PR DESCRIPTION
## Summary
- Add explicit `permissions` block to the caller workflow so the reusable workflow at `TytaniumDev/.github` gets the `pull-requests: write` and `issues: write` permissions it needs
- This workflow has had `startup_failure` on every single run since it was created

## Test plan
- [x] Verify workflow YAML is valid
- [ ] Merge and verify next `pull_request_review` event triggers successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)