### PR TITLE
feat: add auto-approve workflow for owner PRs

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,20 @@
+name: Auto Approve
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  check_suite:
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  checks: read
+
+jobs:
+  auto-approve:
+    if: >-
+      github.event.pull_request.user.login == 'TytaniumDev' ||
+      github.event.sender.login == 'TytaniumDev'
+    uses: TytaniumDev/.github/.github/workflows/auto-approve.yml@main
+    with:
+      owner: TytaniumDev


### PR DESCRIPTION
## Summary
- Adds caller for the shared `auto-approve.yml` reusable workflow from `TytaniumDev/.github`
- Auto-approves PRs from `TytaniumDev` after all required CI checks pass
- Uses `GITHUB_TOKEN` (`github-actions[bot]`) to submit the approval, satisfying branch protection
- Eliminates the need for `--admin` merges, which don't trigger deploy workflows

## How it works
1. PR opened/updated → workflow triggers
2. Verifies PR author is `TytaniumDev`
3. Polls for required CI checks to complete (up to 10 min)
4. If all pass → submits approval review
5. PR can be merged normally → push event triggers deploy

## Test plan
- [ ] Merge this PR and verify the workflow appears in Actions
- [ ] Open a test PR and verify auto-approval after CI passes
- [ ] Merge normally (no `--admin`) and verify deploy triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)