### PR TITLE
fix: prevent readycheck roles cross-user contamination

### DIFF
--- a/core/role_ui.py
+++ b/core/role_ui.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from typing import Any
@@ -43,8 +44,10 @@ class RoleButton(discord.ui.Button["RoleSelectionView"]):
         role_name: str,
         label: str,
         style: discord.ButtonStyle = discord.ButtonStyle.secondary,
+        custom_id_prefix: str = "",
     ):
-        super().__init__(label=label, style=style, custom_id=role_name)
+        custom_id = f"{custom_id_prefix}:{role_name}" if custom_id_prefix else role_name
+        super().__init__(label=label, style=style, custom_id=custom_id)
         self.role_name = role_name
 
     async def callback(self, interaction: discord.Interaction):
@@ -76,6 +79,9 @@ class RoleSelectionView(discord.ui.View):
         self.selected_roles = set(initial_roles or [])
         self.on_save_callback = on_save_callback
 
+        # Unique prefix prevents ViewStore dispatch collisions between concurrent users
+        prefix = os.urandom(8).hex()
+
         roles = [
             (ROLE_TANK, "🛡️ Tank"),
             (ROLE_HEALER, "🌿 Healer"),
@@ -95,7 +101,7 @@ class RoleSelectionView(discord.ui.View):
                 if role_id in self.selected_roles
                 else discord.ButtonStyle.secondary
             )
-            self.add_item(RoleButton(role_id, label, style))
+            self.add_item(RoleButton(role_id, label, style, custom_id_prefix=prefix))
 
     @discord.ui.button(label="Save", style=discord.ButtonStyle.success, row=2)
     async def save(

--- a/core/utils.py
+++ b/core/utils.py
@@ -85,20 +85,14 @@ def _get_player_from_member(member: discord.Member) -> WoWPlayer | None:
     saved_roles = get_player_preference(name)
 
     if saved_roles:
-        logger.info("Creating WoWPlayer for %s from SAVED roles: %s", name, saved_roles)
         return WoWPlayer.create(name=name, roles=saved_roles)
 
     if len(member.roles) > 1:
-        logger.info(
-            "Creating WoWPlayer for %s from DISCORD roles: %s",
-            name,
-            [role.name for role in member.roles],
-        )
         player = WoWPlayer.create(name=name, roles=[role.name for role in member.roles])
         if player.hasRoles():
             return player
         else:
-            logger.info(" - No valid roles found for %s, skipping.", name)
+            logger.info("No valid roles found for %s, skipping.", name)
 
     return None
 


### PR DESCRIPTION
## Summary

- **Fix cross-user role contamination**: Generate a unique `os.urandom(8).hex()` prefix per `RoleSelectionView` instance, so each user's `RoleButton` custom_ids are unique in discord.py's `ViewStore` dispatch table. Previously, concurrent users' views overwrote each other since all buttons shared the same custom_ids ("Tank", "Healer", etc.)
- **Remove spammy logs**: Delete per-player INFO logs ("Creating WoWPlayer from SAVED/DISCORD roles") that fire on every voice state update. Keep the "No valid roles found" diagnostic log

Closes #184

## Test plan

- [x] `./scripts/verify.sh` passes (lint + format + typecheck + 143 tests)
- [ ] Manual test: two users click "Edit My Roles" on the same Role Board simultaneously — each should see/save only their own roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)