### PR TITLE
feat: split role selection into 3 separate ephemeral messages

### DIFF
--- a/core/role_ui.py
+++ b/core/role_ui.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Callable, Coroutine
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 import discord
@@ -42,9 +42,8 @@ class RoleSelectionState:
     on_save_callback: (
         Callable[[discord.Interaction], Coroutine[Any, Any, None]] | None
     ) = None
-
-
-MAIN_SPEC_ROLES = {ROLE_TANK, ROLE_HEALER, ROLE_RANGED, ROLE_MELEE}
+    views: list[discord.ui.View] = field(default_factory=list)
+    messages: list[Any] = field(default_factory=list)
 
 
 class RoleButton(discord.ui.Button[discord.ui.View]):
@@ -178,18 +177,19 @@ class UtilitiesView(discord.ui.View):
         await pref_svc.set_preference(
             self.state.discord_id,
             self.state.player_name,
-            list(self.state.selected_roles),
+            sorted(self.state.selected_roles),
         )
         await interaction.response.send_message(
             f"✅ Saved roles for **{self.state.player_name}**: "
-            f"{', '.join(self.state.selected_roles) if self.state.selected_roles else 'None'}",
+            f"{', '.join(sorted(self.state.selected_roles)) if self.state.selected_roles else 'None'}",
             ephemeral=True,
         )
 
         if self.state.on_save_callback:
             await self.state.on_save_callback(interaction)
 
-        self.stop()
+        for view in self.state.views:
+            view.stop()
 
     @discord.ui.button(label="Clear", style=discord.ButtonStyle.danger, row=1)
     async def clear(
@@ -200,13 +200,24 @@ class UtilitiesView(discord.ui.View):
         pref_svc = get_preference_service()
         await pref_svc.clear_preference(self.state.discord_id)
         self.state.selected_roles.clear()
-        for item in self.children:
-            if isinstance(item, RoleButton):
-                item.style = discord.ButtonStyle.secondary
-        await interaction.response.send_message(
+
+        # Reset button styles across all views
+        for view in self.state.views:
+            for item in view.children:
+                if isinstance(item, RoleButton):
+                    item.style = discord.ButtonStyle.secondary
+
+        # Update utilities message via interaction response
+        await interaction.response.edit_message(view=self)
+
+        # Update main spec and offspec messages
+        for view, msg in zip(self.state.views, self.state.messages, strict=False):
+            if view is not self and msg is not None:
+                await msg.edit(view=view)
+
+        await interaction.followup.send(
             f"🗑️ Cleared roles for **{self.state.player_name}**", ephemeral=True
         )
-        await interaction.edit_original_response(view=self)
 
         if self.state.on_save_callback:
             await self.state.on_save_callback(interaction)
@@ -253,23 +264,32 @@ class RoleBoardView(discord.ui.View):
         state = RoleSelectionState(name, discord_id, set(saved_roles or []), on_save)
         prefix = os.urandom(8).hex()
 
+        main_view = MainSpecView(state, f"{prefix}_main")
+        offspec_view = OffspecView(state, f"{prefix}_off")
+        utilities_view = UtilitiesView(state, f"{prefix}_util")
+        state.views = [main_view, offspec_view, utilities_view]
+
         await interaction.response.defer(ephemeral=True)
 
-        await interaction.followup.send(
+        msg1 = await interaction.followup.send(
             f"Select your roles for **{name}**:\n**Main Spec** (pick one)",
-            view=MainSpecView(state, f"{prefix}_main"),
+            view=main_view,
             ephemeral=True,
+            wait=True,
         )
-        await interaction.followup.send(
+        msg2 = await interaction.followup.send(
             "**Offspec** (pick any)",
-            view=OffspecView(state, f"{prefix}_off"),
+            view=offspec_view,
             ephemeral=True,
+            wait=True,
         )
-        await interaction.followup.send(
+        msg3 = await interaction.followup.send(
             "**Utilities**",
-            view=UtilitiesView(state, f"{prefix}_util"),
+            view=utilities_view,
             ephemeral=True,
+            wait=True,
         )
+        state.messages = [msg1, msg2, msg3]
 
 
 def create_role_board_embed(players: list[WoWPlayer]) -> discord.Embed:

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -157,13 +157,21 @@ class TestUI(unittest.IsolatedAsyncioTestCase):
         mock_get_svc.return_value = mock_svc
 
         state = RoleSelectionState("TestPlayer", "12345", {ROLE_TANK})
-        view = UtilitiesView(state, "test")
+        main_view = MainSpecView(state, "test_main")
+        offspec_view = OffspecView(state, "test_off")
+        utilities_view = UtilitiesView(state, "test_util")
+        state.views = [main_view, offspec_view, utilities_view]
+
         interaction = MagicMock(spec=discord.Interaction)
         interaction.response = MagicMock()
         interaction.response.send_message = AsyncMock()
-        view.stop = MagicMock()
 
-        await view.save.callback(interaction)
+        # Spy on stop for all views
+        main_view.stop = MagicMock()
+        offspec_view.stop = MagicMock()
+        utilities_view.stop = MagicMock()
+
+        await utilities_view.save.callback(interaction)
 
         mock_svc.set_preference.assert_called_once()
         args = mock_svc.set_preference.call_args
@@ -172,7 +180,10 @@ class TestUI(unittest.IsolatedAsyncioTestCase):
         self.assertIn(ROLE_TANK, args[0][2])
 
         interaction.response.send_message.assert_called_once()
-        view.stop.assert_called_once()
+        # All views should be stopped
+        main_view.stop.assert_called_once()
+        offspec_view.stop.assert_called_once()
+        utilities_view.stop.assert_called_once()
 
     @patch("core.role_ui.get_preference_service")
     async def test_clear_method(self, mock_get_svc: MagicMock):
@@ -181,18 +192,37 @@ class TestUI(unittest.IsolatedAsyncioTestCase):
         mock_get_svc.return_value = mock_svc
 
         state = RoleSelectionState("TestPlayer", "12345", {ROLE_TANK})
-        view = UtilitiesView(state, "test")
+        main_view = MainSpecView(state, "test_main")
+        offspec_view = OffspecView(state, "test_off")
+        utilities_view = UtilitiesView(state, "test_util")
+        state.views = [main_view, offspec_view, utilities_view]
+
+        # Mock messages for the other views
+        mock_msg1 = MagicMock()
+        mock_msg1.edit = AsyncMock()
+        mock_msg2 = MagicMock()
+        mock_msg2.edit = AsyncMock()
+        mock_msg3 = MagicMock()
+        mock_msg3.edit = AsyncMock()
+        state.messages = [mock_msg1, mock_msg2, mock_msg3]
+
         interaction = MagicMock(spec=discord.Interaction)
         interaction.response = MagicMock()
-        interaction.response.send_message = AsyncMock()
-        interaction.edit_original_response = AsyncMock()
+        interaction.response.edit_message = AsyncMock()
+        interaction.followup = MagicMock()
+        interaction.followup.send = AsyncMock()
 
-        await view.clear.callback(interaction)
+        await utilities_view.clear.callback(interaction)
 
         mock_svc.clear_preference.assert_called_once_with("12345")
         self.assertEqual(len(state.selected_roles), 0)
-        interaction.response.send_message.assert_called_once()
-        interaction.edit_original_response.assert_called_once()
+        # Utilities message updated via interaction response
+        interaction.response.edit_message.assert_called_once()
+        # Other messages updated via stored references
+        mock_msg1.edit.assert_called_once()
+        mock_msg2.edit.assert_called_once()
+        # Confirmation sent via followup
+        interaction.followup.send.assert_called_once()
 
     async def test_role_board_view_initialization(self):
         mock_callback = AsyncMock()


### PR DESCRIPTION
## Summary

- **Fixes visual disconnect** in the "Edit My Roles" UI where section headers (Main Spec, Offspec, Utilities) were all stacked at the top while buttons appeared below, disconnected from their labels
- **Sends 3 separate ephemeral messages** via `interaction.followup.send()`, each with its own header text + button row for perfect visual grouping
- **Adds `RoleSelectionState` dataclass** as shared mutable state across all 3 views, so selections in any view are reflected when saving
- **Splits `RoleSelectionView`** into `MainSpecView` (mutual exclusivity), `OffspecView` (multi-select), and `UtilitiesView` (Brez/Lust + Save/Clear)

## Test plan

- [x] `ruff check` — no lint errors
- [x] `ruff format` — formatted
- [x] `pyright` — 0 errors
- [x] All 156 unit tests pass
- [ ] Manual: `/readycheck` → "Edit My Roles" → verify 3 separate messages with correct headers
- [ ] Manual: Select main spec → verify mutual exclusivity
- [ ] Manual: Select roles across all 3 messages → Save → verify all selections saved
- [ ] Manual: Clear → verify selections cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)