### PR TITLE
feat: sequential role selection wizard with Next/Done flow

### DIFF
--- a/core/role_ui.py
+++ b/core/role_ui.py
@@ -43,7 +43,6 @@ class RoleSelectionState:
         Callable[[discord.Interaction], Coroutine[Any, Any, None]] | None
     ) = None
     views: list[discord.ui.View] = field(default_factory=list)
-    messages: list[Any] = field(default_factory=list)
     step_contents: list[str] = field(default_factory=list)
 
 
@@ -125,16 +124,15 @@ class NextButton(discord.ui.Button[discord.ui.View]):
         # Send next step
         next_view = self.state.views[next_idx]
         content = self.state.step_contents[next_idx]
-        msg = await interaction.followup.send(
+        await interaction.followup.send(
             content, view=next_view, ephemeral=True, wait=True
         )
-        self.state.messages.append(msg)
 
 
 class NoneButton(discord.ui.Button[discord.ui.View]):
     def __init__(
         self,
-        clear_roles: set[str],
+        clear_roles: frozenset[str],
         state: RoleSelectionState,
         custom_id: str,
     ):
@@ -196,12 +194,14 @@ class MainSpecView(discord.ui.View):
 
 
 class OffspecView(discord.ui.View):
-    OFFSPEC_ROLES = {
-        ROLE_TANK_OFFSPEC,
-        ROLE_HEALER_OFFSPEC,
-        ROLE_RANGED_OFFSPEC,
-        ROLE_MELEE_OFFSPEC,
-    }
+    OFFSPEC_ROLES: frozenset[str] = frozenset(
+        {
+            ROLE_TANK_OFFSPEC,
+            ROLE_HEALER_OFFSPEC,
+            ROLE_RANGED_OFFSPEC,
+            ROLE_MELEE_OFFSPEC,
+        }
+    )
 
     def __init__(self, state: RoleSelectionState, prefix: str):
         super().__init__(timeout=60)
@@ -227,7 +227,11 @@ class OffspecView(discord.ui.View):
                     row=0,
                 )
             )
-        self.add_item(NoneButton(self.OFFSPEC_ROLES, state, f"{prefix}:none"))
+        has_offspec = bool(state.selected_roles & self.OFFSPEC_ROLES)
+        none_btn = NoneButton(self.OFFSPEC_ROLES, state, f"{prefix}:none")
+        if not has_offspec:
+            none_btn.style = discord.ButtonStyle.primary
+        self.add_item(none_btn)
         self.add_item(NextButton(state, f"{prefix}:next"))
 
 
@@ -333,13 +337,12 @@ class RoleBoardView(discord.ui.View):
 
         await interaction.response.defer(ephemeral=True)
 
-        msg1 = await interaction.followup.send(
+        await interaction.followup.send(
             state.step_contents[0],
             view=main_view,
             ephemeral=True,
             wait=True,
         )
-        state.messages = [msg1]
 
 
 def create_role_board_embed(players: list[WoWPlayer]) -> discord.Embed:

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -203,14 +203,11 @@ class TestUI(unittest.IsolatedAsyncioTestCase):
             "**Offspec** (pick any)",
             "**Utilities**",
         ]
-        state.messages = [MagicMock()]
-
         interaction = MagicMock(spec=discord.Interaction)
         interaction.response = MagicMock()
         interaction.response.edit_message = AsyncMock()
-        mock_followup_msg = MagicMock()
         interaction.followup = MagicMock()
-        interaction.followup.send = AsyncMock(return_value=mock_followup_msg)
+        interaction.followup.send = AsyncMock(return_value=MagicMock())
 
         next_button = next(
             item for item in main_view.children if isinstance(item, NextButton)
@@ -229,8 +226,23 @@ class TestUI(unittest.IsolatedAsyncioTestCase):
             ephemeral=True,
             wait=True,
         )
-        # New message should be appended
-        self.assertIn(mock_followup_msg, state.messages)
+
+    async def test_none_button_initial_highlight(self):
+        # No offspec roles selected — NoneButton should start highlighted
+        state = RoleSelectionState("TestPlayer", "12345", set())
+        offspec_view = OffspecView(state, "test_off")
+        none_button = next(
+            item for item in offspec_view.children if isinstance(item, NoneButton)
+        )
+        self.assertEqual(none_button.style, discord.ButtonStyle.primary)
+
+        # With offspec roles selected — NoneButton should start secondary
+        state2 = RoleSelectionState("TestPlayer", "12345", {ROLE_TANK_OFFSPEC})
+        offspec_view2 = OffspecView(state2, "test_off2")
+        none_button2 = next(
+            item for item in offspec_view2.children if isinstance(item, NoneButton)
+        )
+        self.assertEqual(none_button2.style, discord.ButtonStyle.secondary)
 
     async def test_none_button(self):
         state = RoleSelectionState(


### PR DESCRIPTION
## Summary
- Replaces simultaneous 3-message role UI with a step-by-step wizard (Main Spec → Offspec → Utilities)
- Adds `NextButton` to advance between steps and `NoneButton` on offspec to explicitly clear offspec roles
- Replaces Save/Clear buttons with a single "Done ✓" button that auto-saves all selections
- Only the first step message is sent initially; subsequent steps appear when the user clicks Next

## Test plan
- [ ] `/readycheck` → "Edit My Roles" → only Main Spec message appears first
- [ ] Pick main spec → click Next → Offspec message appears
- [ ] Click "None" → offspec buttons deselect; click an offspec role → "None" deselects
- [ ] Click Next → Utilities message appears
- [ ] Click "Done ✓" → roles auto-saved, confirmation shown
- [ ] Verify `python3 -m uv run python -m unittest discover tests` — all 158 tests pass
- [ ] Verify `python3 -m uv run pyright` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)