### PR TITLE
fix: add missing Firestore rule for preferences collection

### DIFF
--- a/FIREBASE_SETUP.md
+++ b/FIREBASE_SETUP.md
@@ -53,10 +53,13 @@ For the main bot deploy (e.g. to a Raspberry Pi via `.github/workflows/deploy.ym
        match /channels/{channelId} {
          allow read, write: if true;
        }
+       match /preferences/{docId} {
+         allow read, write: if true;
+       }
      }
    }
    ```
-   *Warning: This allows anyone to read/write guild and channel documents. For a production app, you should restrict writes to only the fields the frontend needs to update (like status).*
+   *Warning: This allows anyone to read/write guild, channel, and preference documents. For a production app, you should restrict writes to only the fields the frontend needs to update (like status and role preferences).*
 
 ## 6. Document cleanup (database growth)
 


### PR DESCRIPTION
## Summary
- Adds `preferences/{docId}` to the documented Firestore security rules in `FIREBASE_SETUP.md`
- The activity role editor (added in 289fcdf) writes to the `preferences` collection, but the rules only allowed access to `guilds` and `channels`, causing permission-denied errors when saving roles from the activity frontend

Closes #194

## Test plan
- [ ] Update Firestore rules in Firebase Console to include the new `preferences` rule
- [ ] Open an activity lobby and save role preferences — should succeed without error
- [ ] Verify the bot picks up the saved preferences (refresh signal works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)