### PR TITLE
chore: add one-time Doppler migration workflow

### DIFF
--- a/.github/workflows/migrate-secrets-to-doppler.yml
+++ b/.github/workflows/migrate-secrets-to-doppler.yml
@@ -1,0 +1,49 @@
+name: Migrate Secrets to Doppler
+on:
+  workflow_dispatch: # Manual trigger only
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Doppler CLI
+        uses: dopplerhq/cli-action@v3
+
+      - name: Push secrets to Doppler
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+          DISCORD_APPLICATION_ID: ${{ secrets.DISCORD_APPLICATION_ID }}
+          FIREBASE_CREDENTIALS_JSON: ${{ secrets.FIREBASE_CREDENTIALS_JSON }}
+          DEVELOPER_ID: ${{ secrets.DEVELOPER_ID }}
+          GH_ISSUE_TOKEN: ${{ secrets.GH_ISSUE_TOKEN }}
+          VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
+          VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
+          VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+          VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
+          VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
+          VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
+          PI_HOST: ${{ secrets.PI_HOST }}
+          PI_USER: ${{ secrets.PI_USER }}
+          PI_APP_DIR: ${{ secrets.PI_APP_DIR }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+        run: |
+          doppler secrets set \
+            BOT_TOKEN="${BOT_TOKEN}" \
+            DISCORD_APPLICATION_ID="${DISCORD_APPLICATION_ID}" \
+            FIREBASE_CREDENTIALS_JSON="${FIREBASE_CREDENTIALS_JSON}" \
+            DEVELOPER_ID="${DEVELOPER_ID}" \
+            GITHUB_TOKEN="${GH_ISSUE_TOKEN}" \
+            ACTIVITY_URL="https://tytaniumdev.github.io/MythicPlusDiscordBot/" \
+            VITE_FIREBASE_API_KEY="${VITE_FIREBASE_API_KEY}" \
+            VITE_FIREBASE_AUTH_DOMAIN="${VITE_FIREBASE_AUTH_DOMAIN}" \
+            VITE_FIREBASE_PROJECT_ID="${VITE_FIREBASE_PROJECT_ID}" \
+            VITE_FIREBASE_STORAGE_BUCKET="${VITE_FIREBASE_STORAGE_BUCKET}" \
+            VITE_FIREBASE_MESSAGING_SENDER_ID="${VITE_FIREBASE_MESSAGING_SENDER_ID}" \
+            VITE_FIREBASE_APP_ID="${VITE_FIREBASE_APP_ID}" \
+            PI_HOST="${PI_HOST}" \
+            PI_USER="${PI_USER}" \
+            PI_APP_DIR="${PI_APP_DIR}" \
+            GHCR_TOKEN="${GHCR_TOKEN}" \
+            --no-interactive
+          echo "Migration complete!"


### PR DESCRIPTION
One-time workflow to migrate GitHub secrets to Doppler. Will delete after running.