### PR TITLE
fix: mask Doppler secrets and scope deploy.yml to least-privilege

### DIFF
--- a/.github/workflows/deploy-activity.yml
+++ b/.github/workflows/deploy-activity.yml
@@ -32,7 +32,17 @@ jobs:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         run: |
           DELIM=$(openssl rand -hex 16)
-          doppler secrets download --no-file --format json | jq -r --arg d "$DELIM" '
+          SECRETS=$(doppler secrets download --no-file --format json)
+          # Mask each secret value so it cannot appear in workflow logs
+          echo "$SECRETS" | jq -r '
+            to_entries[]
+            | select(.key == "DISCORD_APPLICATION_ID" or (.key | startswith("VITE_FIREBASE_")))
+            | .value
+          ' | while IFS= read -r val; do
+            [ -n "$val" ] && echo "::add-mask::$val"
+          done
+          # Export filtered secrets
+          echo "$SECRETS" | jq -r --arg d "$DELIM" '
             to_entries[]
             | select(.key == "DISCORD_APPLICATION_ID" or (.key | startswith("VITE_FIREBASE_")))
             | "\(.key)<<\($d)\n\(.value)\n\($d)"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,8 +59,17 @@ jobs:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         run: |
           DELIM=$(openssl rand -hex 16)
-          doppler secrets download --no-file --format json | jq -r --arg d "$DELIM" '
-            to_entries[] | "\(.key)<<\($d)\n\(.value)\n\($d)"
+          SECRETS=$(doppler secrets download --no-file --format json)
+          KEYS='["TS_OAUTH_CLIENT_ID","TS_OAUTH_SECRET","PI_SSH_KEY","PI_HOST","PI_USER","PI_APP_DIR","FIREBASE_CREDENTIALS_JSON","GH_ISSUE_TOKEN","GHCR_TOKEN","BOT_TOKEN","DISCORD_APPLICATION_ID"]'
+          # Mask each secret value so it cannot appear in workflow logs
+          echo "$SECRETS" | jq -r --argjson keys "$KEYS" '
+            to_entries[] | select(.key | IN($keys[])) | .value
+          ' | while IFS= read -r val; do
+            [ -n "$val" ] && echo "::add-mask::$val"
+          done
+          # Export only the secrets needed by the deploy job
+          echo "$SECRETS" | jq -r --argjson keys "$KEYS" --arg d "$DELIM" '
+            to_entries[] | select(.key | IN($keys[])) | "\(.key)<<\($d)\n\(.value)\n\($d)"
           ' >> "$GITHUB_ENV"
 
       - name: Connect to Tailscale


### PR DESCRIPTION
## Summary
- Add `::add-mask::` for each exported Doppler secret value in both `deploy.yml` and `deploy-activity.yml` so values cannot leak in GitHub Actions workflow logs
- Filter `deploy.yml` to export only the 11 specific Doppler keys the deploy job uses, instead of dumping all secrets into `$GITHUB_ENV` (reduces blast radius if a third-party action is compromised)
- `deploy-activity.yml` already filtered secrets — only the masking fix was needed there

Addresses security issues identified in TytaniumDev/MagicBracketSimulator#101.

## Test plan
- [ ] Verify `deploy.yml` workflow runs successfully on merge (secrets load and deploy completes)
- [ ] Verify `deploy-activity.yml` workflow runs successfully (Pages build completes)
- [ ] Confirm no secret values appear in plain text in workflow logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)