### PR TITLE
fix: enable Sentry tracing for release health widgets

### DIFF
--- a/packages/bot/src/core/sentry.ts
+++ b/packages/bot/src/core/sentry.ts
@@ -8,7 +8,7 @@ export function initSentry() {
     dsn: SENTRY_DSN,
     release: GIT_SHA ? `mythicplus-bot@${GIT_SHA}` : undefined,
     environment: process.env.NODE_ENV ?? 'production',
-    tracesSampleRate: 0,
+    tracesSampleRate: 0.1,
   });
 }
 


### PR DESCRIPTION
## Summary

- Set `tracesSampleRate` from `0` to `0.1` (10% sampling) in Sentry SDK init
- This was the sole blocker preventing the Sentry dashboard's **Apdex**, **Crash Free Sessions**, **Crash Free Users**, and **Number of Releases** widgets from populating
- The `release` field (via `GIT_SHA`) and session tracking were already correctly configured — they just had no transaction data to work with

## What was already correct (no changes needed)

- **GIT_SHA pipeline**: `deploy.yml` passes `github.sha` → Dockerfile ARG/ENV → `config.ts` → Sentry `release` field
- **Session tracking**: `@sentry/node` v10 enables auto session tracking by default
- **No duplicate `Sentry.init()` calls** elsewhere in the codebase

## Test plan

- [ ] `./scripts/verify-ts.sh` passes (typecheck + lint + tests)
- [ ] After deploy, verify Sentry dashboard widgets begin populating within minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)