### PR TITLE
fix: clear stale guild-level slash commands to remove duplicates

### DIFF
--- a/packages/bot/src/main.ts
+++ b/packages/bot/src/main.ts
@@ -343,6 +343,21 @@ async function main() {
       const globalBody = [...commandsJson, ...entryPointCommands];
       await rest.put(Routes.applicationCommands(appId), { body: globalBody });
       logger.info(`Registered ${commands.length} slash commands globally`);
+
+      // Clear stale guild-level commands (duplicates from old per-guild registration)
+      for (const guild of readyClient.guilds.cache.values()) {
+        try {
+          const guildCmds = (await rest.get(
+            Routes.applicationGuildCommands(appId, guild.id),
+          )) as { id: string }[];
+          if (guildCmds.length > 0) {
+            await rest.put(Routes.applicationGuildCommands(appId, guild.id), { body: [] });
+            logger.info(`Cleared ${guildCmds.length} stale guild commands from ${guild.name}`);
+          }
+        } catch (guildErr) {
+          logger.warn(`Could not clear guild commands for ${guild.name}: ${guildErr}`);
+        }
+      }
     } catch (e) {
       logger.error(`Failed to register slash commands: ${e}`);
     }


### PR DESCRIPTION
## Summary
- On startup, the bot now checks each guild for leftover guild-level slash command registrations and clears them
- This removes duplicate commands in the Discord UI caused by stale per-guild registrations from a previous bot version
- The cleanup is a no-op after the first run (skips guilds with 0 guild commands)

## Test plan
- [ ] Deploy and verify bot logs show "Cleared N stale guild commands from ..." on first startup
- [ ] Confirm Discord command picker shows each command only once
- [ ] Verify subsequent restarts skip cleanup (no "Cleared" log lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)