### PR TITLE
ci: deploy Firestore rules automatically on merge to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,7 @@ jobs:
   deploy-firestore-rules:
     needs: [ci]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
     steps:
@@ -48,8 +49,11 @@ jobs:
         run: |
           echo "$FIREBASE_CREDENTIALS_JSON" > "$RUNNER_TEMP/firebase-sa.json"
           export GOOGLE_APPLICATION_CREDENTIALS="$RUNNER_TEMP/firebase-sa.json"
-          npx firebase-tools deploy --only firestore:rules --non-interactive
-          rm -f "$RUNNER_TEMP/firebase-sa.json"
+          npx firebase-tools@14 deploy --only firestore:rules --non-interactive
+
+      - name: Clean up credentials
+        if: always()
+        run: rm -f "$RUNNER_TEMP/firebase-sa.json"
 
   build-and-push:
     needs: [ci]


### PR DESCRIPTION
## Summary
- Adds a `deploy-firestore-rules` job to `deploy.yml` that runs after CI passes, in parallel with the Docker build
- Loads `FIREBASE_CREDENTIALS_JSON` from Doppler and uses `firebase-tools` to deploy `firestore.rules`
- Fixes the "Report Bad Group" feature which was failing because the `badGroupReports` security rules were never deployed to the live Firebase project (rules already deployed manually as an immediate fix)

## Test plan
- [ ] Verify the `deploy-firestore-rules` job runs successfully in the deploy workflow
- [ ] Confirm "Report Bad Group" form works in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)