### PR TITLE
fix: add --force to firebase deploy to skip API enablement check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           echo "$FIREBASE_CREDENTIALS_JSON" > "$RUNNER_TEMP/firebase-sa.json"
           export GOOGLE_APPLICATION_CREDENTIALS="$RUNNER_TEMP/firebase-sa.json"
-          npx firebase-tools@14 deploy --only firestore:rules --non-interactive
+          npx firebase-tools@14 deploy --only firestore:rules --non-interactive --force
 
       - name: Clean up credentials
         if: always()


### PR DESCRIPTION
## Summary
- Fixes the `deploy-firestore-rules` job failing with a 403 on `serviceusage.googleapis.com`
- The service account can deploy Firestore rules but lacks permission to query the Service Usage API
- Adding `--force` skips the unnecessary API enablement check

## Test plan
- [ ] Merge and verify the `deploy-firestore-rules` job passes on the next push to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)