### PR TITLE
fix: correct Wago.io project ID in addon .toc

### DIFF
--- a/addon/MythicPlusWheel.toc
+++ b/addon/MythicPlusWheel.toc
@@ -6,7 +6,7 @@
 ## SavedVariables: MythicPlusWheelDB
 ## IconTexture: Interface\Icons\INV_Misc_GroupNeedMore
 ## X-Curse-Project-ID: 1484744
-## X-Wago-ID: wheelson
+## X-Wago-ID: bGoyPq60
 
 # Embedded Libraries
 libs\LibStub\LibStub.lua


### PR DESCRIPTION
## Summary
- Fix `X-Wago-ID` from placeholder slug `wheelson` to actual project ID `bGoyPq60`

## Test plan
- [x] Wago.io project ID confirmed by project owner
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)