### PR TITLE
fix: symlink .git into addon dir for packager VCS detection

### DIFF
--- a/.github/workflows/deploy-addon.yml
+++ b/.github/workflows/deploy-addon.yml
@@ -60,6 +60,9 @@ jobs:
           git tag -a "$TAG" -m "Addon release ${VERSION}"
           git push origin "$TAG"
 
+      - name: Symlink .git into addon for packager VCS detection
+        run: ln -s ../.git addon/.git
+
       - name: Package and release addon
         uses: BigWigsMods/packager@v2
         with:


### PR DESCRIPTION
## Summary
- Fix the deploy-addon workflow failing with `No Git, SVN, or Hg checkout found in "addon"`
- The BigWigsMods/packager's `-t addon` flag checks for `addon/.git`, which doesn't exist in our monorepo — `.git` is at the repo root
- Add a symlink step (`ln -s ../.git addon/.git`) before the packager so its VCS detection passes

Fixes: https://github.com/TytaniumDev/MythicPlusDiscordBot/actions/runs/23035776322

## Test plan
- [ ] CI passes
- [ ] Re-run Deploy Addon workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)