### PR TITLE
fix: remove [skip ci] from snapshot commits to unblock branch protection

### DIFF
--- a/.github/workflows/verify-activity.yml
+++ b/.github/workflows/verify-activity.yml
@@ -25,7 +25,8 @@ jobs:
         id: bot-check
         run: |
           AUTHOR=$(git log -1 --format='%an')
-          if [ "$AUTHOR" = "github-actions[bot]" ]; then
+          MSG=$(git log -1 --format='%s')
+          if [ "$AUTHOR" = "github-actions[bot]" ] && [[ "$MSG" == "chore: update visual test snapshots"* ]]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "Skipping — last commit was an automated snapshot update."
           fi


### PR DESCRIPTION
## Summary
- Remove `[skip ci]` from the auto-committed snapshot update message in `verify-activity.yml` so that CI checks still run on the latest commit and branch protection is satisfied
- Add a bot-check guard that skips all heavy steps (Node setup, npm ci, Playwright) when the workflow is re-triggered by its own snapshot commit, preventing wasteful re-runs

## Test plan
- [ ] Push a change to `activity/` that causes snapshot diffs — verify CI runs on the auto-committed snapshot update
- [ ] Verify the `verify-activity` workflow exits early on the bot-triggered re-run instead of running Playwright again

🤖 Generated with [Claude Code](https://claude.com/claude-code)