### PR TITLE
fix: enable vertical scrolling in Storybook pages

### DIFF
--- a/activity/.storybook/preview-head.html
+++ b/activity/.storybook/preview-head.html
@@ -1,0 +1,6 @@
+<style>
+  /* Override overflow:hidden from index.css so Storybook stories can scroll */
+  html, body {
+    overflow: auto !important;
+  }
+</style>


### PR DESCRIPTION
## Summary
- Adds `activity/.storybook/preview-head.html` to override `overflow: hidden` on `html, body` within the Storybook preview iframe
- The global `index.css` sets `overflow: hidden` on `html/body`, relying on the `#app` wrapper for scrolling — but Storybook renders stories without `#app`, so all pages were locked to no-scroll

## Test plan
- [ ] Open Storybook (`npm run storybook` in `activity/`)
- [ ] Navigate to any story with content taller than the viewport
- [ ] Verify vertical scrolling works
- [ ] Verify the actual app still behaves correctly (no scrolling regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>