### PR TITLE
feat: add WoW class color design tokens to Storybook

### DIFF
--- a/activity.pen
+++ b/activity.pen
@@ -24084,8 +24084,5 @@
         }
       ]
     }
-  },
-  "imports": {
-    "P": "design_system.lib.pen"
   }
 }

--- a/activity/src/docs/DesignTokens.stories.tsx
+++ b/activity/src/docs/DesignTokens.stories.tsx
@@ -99,6 +99,24 @@ export const Colors: Story = {
           <Swatch name="Heading" cssVar="--text-heading" />
         </TokenGrid>
       </Section>
+
+      <Section title="Class Colors">
+        <TokenGrid>
+          <Swatch name="Death Knight" cssVar="--class-death-knight" />
+          <Swatch name="Demon Hunter" cssVar="--class-demon-hunter" />
+          <Swatch name="Druid" cssVar="--class-druid" />
+          <Swatch name="Evoker" cssVar="--class-evoker" />
+          <Swatch name="Hunter" cssVar="--class-hunter" />
+          <Swatch name="Mage" cssVar="--class-mage" />
+          <Swatch name="Monk" cssVar="--class-monk" />
+          <Swatch name="Paladin" cssVar="--class-paladin" />
+          <Swatch name="Priest" cssVar="--class-priest" />
+          <Swatch name="Rogue" cssVar="--class-rogue" />
+          <Swatch name="Shaman" cssVar="--class-shaman" />
+          <Swatch name="Warlock" cssVar="--class-warlock" />
+          <Swatch name="Warrior" cssVar="--class-warrior" />
+        </TokenGrid>
+      </Section>
     </div>
   ),
 };

--- a/activity/src/index.css
+++ b/activity/src/index.css
@@ -39,6 +39,20 @@
   --color-brez: var(--color-gold);
   --color-lust: #e85d26;
 
+  --class-death-knight: #E04050;
+  --class-demon-hunter: #B84FDE;
+  --class-druid: #FF7C0A;
+  --class-evoker: #33937F;
+  --class-hunter: #AAD372;
+  --class-mage: #3FC7EB;
+  --class-monk: #00FF98;
+  --class-paladin: #F48CBA;
+  --class-priest: #FFFFFF;
+  --class-rogue: #FFF468;
+  --class-shaman: #1E90FF;
+  --class-warlock: #8788EE;
+  --class-warrior: #C69B6D;
+
   --text-primary: #e5e7eb;
   --text-secondary: #b0b8c4;
   --text-heading: #ffffff;


### PR DESCRIPTION
## Summary
- Add all 13 WoW class colors as CSS custom properties (`--class-death-knight` through `--class-warrior`) in `activity/src/index.css`
- Add a "Class Colors" section to the Docs/Design Tokens > Colors Storybook story with swatches for each class
- Colors sourced from the Pencil design file

## Test plan
- [ ] Run `npm run typecheck` in `activity/` — passes
- [ ] Open Storybook and verify "Docs/Design Tokens > Colors" shows the new Class Colors section with all 13 swatches
- [ ] Verify color values match the WoW class color standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)