### PR TITLE
fix: update text field immediately when selecting character search result

### DIFF
--- a/activity/src/components/ui/CharacterSearchInput.tsx
+++ b/activity/src/components/ui/CharacterSearchInput.tsx
@@ -52,6 +52,7 @@ export function CharacterSearchInput({
               onClick={() => {
                 setShowDropdown(false);
                 setSearchQuery('');
+                onChange(`${r.name}-${r.realm}`);
                 onSelect(r);
               }}
             >

--- a/activity/src/index.css
+++ b/activity/src/index.css
@@ -1749,7 +1749,8 @@ body {
   position: absolute;
   top: 100%;
   left: 0;
-  right: 0;
+  min-width: 100%;
+  width: max-content;
   z-index: 50;
   background: var(--bg-secondary);
   border: 1px solid var(--border-subtle);
@@ -1762,8 +1763,8 @@ body {
 
 .character-search-result {
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  gap: 12px;
   width: 100%;
   padding: 8px 12px;
   background: none;
@@ -1772,6 +1773,7 @@ body {
   color: var(--text-primary);
   font-size: 13px;
   text-align: left;
+  white-space: nowrap;
 }
 
 .character-search-result:hover {
@@ -1788,14 +1790,15 @@ body {
 }
 
 @keyframes spin {
-  to { transform: translateY(-50%) rotate(360deg); }
+  to { transform: rotate(360deg); }
 }
 
 .character-search-loading {
   position: absolute;
   right: 10px;
-  top: 50%;
-  transform: translateY(-50%);
+  top: 0;
+  bottom: 0;
+  margin: auto 0;
   width: 14px;
   height: 14px;
   border: 2px solid var(--border-subtle);


### PR DESCRIPTION
## Summary
- **Fix autofill:** Clicking a character search result now immediately updates the text field to `Name-Realm` by calling `onChange` before `onSelect`. Previously the input stayed stuck because it relied on an async Firebase lookup that often failed.
- **Fix spinner animation:** The loading spinner was drifting vertically instead of spinning in place. Replaced the `top: 50%; transform: translateY(-50%)` centering with `top: 0; bottom: 0; margin: auto 0` so the `@keyframes spin` can use a simple `rotate()` without transform conflicts.
- **Improve dropdown layout:** Added `gap: 12px` and `white-space: nowrap` to search results, and changed the dropdown from fixed-width (`right: 0`) to `width: max-content` so results display on a single line.

## Test plan
- [ ] Type "Tytaniormu" in the In-Game Name field → dropdown shows "Tytaniormu - Uldum · Hunter"
- [ ] Click the result → text field immediately updates to "Tytaniormu-Uldum"
- [ ] Verify the loading spinner spins in place without vertical drift
- [ ] Verify dropdown items show name and realm·class on one line with spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)