### PR TITLE
fix: remove AppCheck enforcement from lookupCharacter

### DIFF
--- a/packages/functions/src/lookupCharacter.ts
+++ b/packages/functions/src/lookupCharacter.ts
@@ -45,7 +45,6 @@ export function buildCharacterResult(
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 1 day
 
 export const lookupCharacter = onCall(
-  { enforceAppCheck: true },
   async (request) => {
     if (!request.auth) {
       throw new HttpsError('unauthenticated', 'Authentication required');


### PR DESCRIPTION
## Summary
- PR #371 added `enforceAppCheck: true` to `lookupCharacter`, but the frontend (`activity/src/firebase.ts`) never initializes Firebase App Check
- Every character lookup silently fails, so `mediaUrl` is never set and player profile images never appear
- Removes `enforceAppCheck` while keeping auth + rate limiting intact

## Test plan
- [x] Functions typecheck passes
- [x] All 13 functions tests pass
- [x] Verified Battle.net image URLs load fine on GitHub Pages (no CORS issue)
- [x] Verified profile image renders correctly in demo mode (Raider.io path)
- [ ] After deploy: search a character in production lobby → profile image should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)