### PR TITLE
feat: show affix bar on all screens via HeaderBar

### DIFF
--- a/activity/src/components/HeaderBar.stories.tsx
+++ b/activity/src/components/HeaderBar.stories.tsx
@@ -1,11 +1,13 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
+import { withStore } from '../../.storybook/decorators';
 import { HeaderBar } from './HeaderBar';
 import { CountBadge } from './ui';
 
 const meta = {
   title: 'Organisms/HeaderBar',
   component: HeaderBar,
+  decorators: [withStore({ isDemoMode: true })],
   parameters: { layout: 'fullscreen' },
 } satisfies Meta<typeof HeaderBar>;
 

--- a/activity/src/components/HeaderBar.tsx
+++ b/activity/src/components/HeaderBar.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import { IconButton } from './ui';
+import { AffixBar } from './AffixBar';
 import wheelsonIcon from '../img/wheelson.png';
 
 const BackArrow = () => (
@@ -30,7 +31,7 @@ export function HeaderBar({
   extra,
   className = '',
 }: HeaderBarProps) {
-  return (
+  return (<>
     <header className={`header-bar ${className}`}>
       {onBack ? (
         <IconButton
@@ -76,5 +77,7 @@ export function HeaderBar({
         </a>
       </div>
     </header>
+    <AffixBar />
+  </>
   );
 }

--- a/activity/src/views/LobbyView.tsx
+++ b/activity/src/views/LobbyView.tsx
@@ -5,7 +5,6 @@ import { PlayerChip } from '../components/PlayerChip';
 import { PlayerCard } from '../components/PlayerCard';
 import { EditPlayerModal } from '../components/EditPlayerModal';
 import { SpinWarningDialog } from '../components/SpinWarningDialog';
-import { AffixBar } from '../components/AffixBar';
 import { HeaderBar } from '../components/HeaderBar';
 import { PrimaryCTA, RoleSectionHeader } from '../components/ui';
 import { CollapsibleRoleSection } from '../components/CollapsibleRoleSection';
@@ -126,7 +125,6 @@ export function LobbyView({ onNavigate }: LobbyViewProps) {
           className="app-header"
           subtitleId="player-count"
         />
-        <AffixBar />
         <main className="content-area">
           <section id="view-lobby">
             <div id="player-list">
@@ -158,7 +156,6 @@ export function LobbyView({ onNavigate }: LobbyViewProps) {
           </span>
         }
       />
-      <AffixBar />
       <main className="content-area">
         <section id="view-lobby">
 


### PR DESCRIPTION
## Summary
- Moved `AffixBar` into the `HeaderBar` component so it renders below the header on every screen
- Removed standalone `<AffixBar />` usage from `LobbyView`
- Added store decorator to HeaderBar stories so the `useAffixes` hook works in Storybook

## Test plan
- [ ] Verify affix bar appears on all views (Home, Channels, Lobby, Results, Wheels, Setup, Identity)
- [ ] Verify affix data loads correctly from Firestore/demo mode
- [ ] Run `./scripts/verify-activity.sh` for typecheck + build + Playwright tests
- [ ] Update Playwright snapshots if needed (`./scripts/playwright-docker.sh --update-snapshots`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>