### PR TITLE
chore: stop auto-labeling reported issues with jules

### DIFF
--- a/packages/bot/src/core/issues.ts
+++ b/packages/bot/src/core/issues.ts
@@ -185,8 +185,7 @@ export async function submitGithubIssueModal(
     }
   }
 
-  const labels =
-    data.issueType === 'bug' ? ['bug', 'jules'] : ['enhancement', 'jules'];
+  const labels = data.issueType === 'bug' ? ['bug'] : ['enhancement'];
   return createGithubIssue(safeTitle, body, labels);
 }
 

--- a/packages/bot/tests/issues.test.ts
+++ b/packages/bot/tests/issues.test.ts
@@ -109,7 +109,7 @@ describe('submitGithubIssueModal', () => {
     expect(body.title).toBe('Bug Title');
     expect(body.body).toContain('Bug Description');
     expect(body.body).toContain('Steps');
-    expect(body.labels).toEqual(['bug', 'jules']);
+    expect(body.labels).toEqual(['bug']);
 
     const expectedVersion =
       '[`abc1234`](https://github.com/owner/repo/commit/abc123456)';


### PR DESCRIPTION
## Summary
- Remove `jules` from labels applied by `submitGithubIssueModal` so bug and feature reports created via the Discord modal no longer auto-tag `jules`
- Update matching test assertion

## Test plan
- [x] `./scripts/verify-ts.sh` (lint + typecheck + 227 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)