### PR TITLE
refactor: activity cleanup, storybook coverage, sentry routing

### DIFF
--- a/activity/src/App.tsx
+++ b/activity/src/App.tsx
@@ -163,12 +163,8 @@ export function App() {
     return () => window.removeEventListener('popstate', handler);
   }, []);
 
-  const handleNavigateHome = useCallback(() => {
-    navigateTo('home');
-  }, [navigateTo]);
-
   return (
-    <Layout onNavigateHome={handleNavigateHome}>
+    <Layout>
       {currentView === 'home' && <HomeView onNavigate={navigateTo} />}
       {currentView === 'channels' && <ChannelsView onNavigate={navigateTo} />}
       {currentView === 'identity' && <IdentityView onNavigate={navigateTo} />}

--- a/activity/src/components/CollapsibleRoleSection.stories.tsx
+++ b/activity/src/components/CollapsibleRoleSection.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { CollapsibleRoleSection } from './CollapsibleRoleSection';
+
+const meta = {
+  title: 'Molecules/CollapsibleRoleSection',
+  component: CollapsibleRoleSection,
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof CollapsibleRoleSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const SampleChildren = () => (
+  <div className="role-section__children">
+    <div className="player-chip">
+      <div className="chip-header"><span>Valeria</span></div>
+    </div>
+    <div className="player-chip">
+      <div className="chip-header"><span>Grim</span></div>
+    </div>
+  </div>
+);
+
+export const Tank: Story = {
+  args: {
+    label: 'Tanks',
+    count: 2,
+    color: 'tank',
+    children: <SampleChildren />,
+  },
+};
+
+export const Healer: Story = {
+  args: {
+    label: 'Heal',
+    count: 1,
+    color: 'healer',
+    children: <SampleChildren />,
+  },
+};
+
+export const DPS: Story = {
+  args: {
+    label: 'Ranged',
+    count: 3,
+    color: 'dps',
+    children: <SampleChildren />,
+  },
+};
+
+export const DefaultCollapsed: Story = {
+  args: {
+    label: 'Melee',
+    count: 4,
+    color: 'dps',
+    defaultCollapsed: true,
+    children: <SampleChildren />,
+  },
+};

--- a/activity/src/components/ConfirmBackDialog.stories.tsx
+++ b/activity/src/components/ConfirmBackDialog.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ConfirmBackDialog } from './ConfirmBackDialog';
+
+const meta = {
+  title: 'Organisms/ConfirmBackDialog',
+  component: ConfirmBackDialog,
+  parameters: { layout: 'fullscreen' },
+  args: {
+    onConfirm: () => {},
+    onCancel: () => {},
+  },
+} satisfies Meta<typeof ConfirmBackDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DuringSpin: Story = { args: {} };
+
+export const LeaveResults: Story = {
+  args: {
+    title: 'Leave Results?',
+    message: 'This will end the current session and return everyone to the lobby.',
+  },
+};

--- a/activity/src/components/EditPlayerModal.stories.tsx
+++ b/activity/src/components/EditPlayerModal.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { withStore } from '../../.storybook/decorators';
+import { EditPlayerModal } from './EditPlayerModal';
+import { mockPlayers, mockChannelData } from '../lib/mockData';
+
+const meta = {
+  title: 'Organisms/EditPlayerModal',
+  component: EditPlayerModal,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    withStore({
+      currentPlayerId: '100000000000000007',
+      channelData: mockChannelData,
+    }),
+  ],
+  args: {
+    onClose: () => {},
+  },
+} satisfies Meta<typeof EditPlayerModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Tank: Story = { args: { player: mockPlayers[4] } };
+export const Healer: Story = { args: { player: mockPlayers[0] } };
+export const CurrentUser: Story = { args: { player: mockPlayers[6] } };

--- a/activity/src/components/EditPlayerModal.tsx
+++ b/activity/src/components/EditPlayerModal.tsx
@@ -1,17 +1,9 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { WoWPlayer } from '../types';
-import { getPrimaryRole } from '../lib/roles';
+import { getPrimaryRole, getRoleColor } from '../lib/roles';
 import { CharacterHeader } from './CharacterHeader';
 import { Divider } from './ui';
 import { RoleEditor } from './RoleEditor';
-
-const ROLE_COLOR_MAP: Record<string, string> = {
-  tank: 'var(--color-tank)',
-  healer: 'var(--color-healer)',
-  ranged: 'var(--color-dps)',
-  melee: 'var(--color-dps)',
-  unassigned: 'var(--text-secondary)',
-};
 
 interface EditPlayerModalProps {
   player: WoWPlayer;
@@ -38,8 +30,7 @@ export function EditPlayerModal({ player, onClose }: EditPlayerModalProps) {
     return () => document.removeEventListener('keydown', handler);
   }, [onClose]);
 
-  const primaryRole = getPrimaryRole(player);
-  const color = ROLE_COLOR_MAP[primaryRole] ?? ROLE_COLOR_MAP.unassigned;
+  const color = getRoleColor(getPrimaryRole(player));
 
   return (
     <div className="edit-modal-backdrop" ref={backdropRef} onClick={handleBackdropClick}>

--- a/activity/src/components/GroupCard.tsx
+++ b/activity/src/components/GroupCard.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
-import { WoWGroup, WoWPlayer } from '../types';
+import { WoWGroup } from '../types';
 import { useAppStore } from '../store/store';
 import { utilityIcons } from '../lib/roles';
+import { RoleRow } from './ui';
 import { generateInviteCommand } from '@mythicplus/shared';
 
 interface GroupCardProps {
@@ -10,29 +11,6 @@ interface GroupCardProps {
   label?: string;
   hideEmpty?: boolean;
   compact?: boolean;
-}
-
-function RoleRow({ color, roleLabel, name, player, isOffspec, compact }: {
-  color: string;
-  roleLabel: string;
-  name: string;
-  player?: WoWPlayer | null;
-  isOffspec?: boolean;
-  compact?: boolean;
-}) {
-  return (
-    <div className={compact ? 'compact-role' : 'group-role'}>
-      <span
-        className={`role-indicator ${roleLabel.toLowerCase()}${isOffspec ? ' offspec' : ''}`}
-        style={isOffspec ? { borderColor: color } : { background: color }}
-        role="img"
-        aria-label={`${roleLabel}${isOffspec ? ' (offspec)' : ''}`}
-        title={`${roleLabel}${isOffspec ? ' (offspec)' : ''}`}
-      />
-      {!compact && <span className="role-label">{roleLabel}</span>}
-      <span className="role-name">{name}{utilityIcons(player)}</span>
-    </div>
-  );
 }
 
 async function copyToClipboard(text: string): Promise<void> {
@@ -82,7 +60,7 @@ export function GroupCard({ group, index, label, hideEmpty = false, compact = fa
           color="var(--color-tank)"
           roleLabel="Tank"
           name={group.tank?.name || 'None'}
-          player={group.tank}
+          suffix={utilityIcons(group.tank)}
           isOffspec={group.tank ? group.tank.mainRole !== 'tank' : false}
           compact={compact}
         />
@@ -92,7 +70,7 @@ export function GroupCard({ group, index, label, hideEmpty = false, compact = fa
           color="var(--color-healer)"
           roleLabel="Healer"
           name={group.healer?.name || 'None'}
-          player={group.healer}
+          suffix={utilityIcons(group.healer)}
           isOffspec={group.healer ? group.healer.mainRole !== 'healer' : false}
           compact={compact}
         />
@@ -103,7 +81,7 @@ export function GroupCard({ group, index, label, hideEmpty = false, compact = fa
           color="var(--color-dps)"
           roleLabel="DPS"
           name={d.name}
-          player={d}
+          suffix={utilityIcons(d)}
           isOffspec={d.mainRole !== null && d.mainRole !== 'ranged' && d.mainRole !== 'melee'}
           compact={compact}
         />

--- a/activity/src/components/Layout.stories.tsx
+++ b/activity/src/components/Layout.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { withStore } from '../../.storybook/decorators';
+import { Layout } from './Layout';
+
+const meta = {
+  title: 'Atoms/Layout',
+  component: Layout,
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof Layout>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: (
+      <div style={{ padding: '2rem', color: 'var(--text-primary)' }}>
+        <h1>Page content goes here</h1>
+      </div>
+    ),
+  },
+};
+
+export const WithStatusMessage: Story = {
+  decorators: [withStore({ statusMessage: 'Connection lost. Retrying...' })],
+  args: {
+    children: (
+      <div style={{ padding: '2rem', color: 'var(--text-primary)' }}>
+        <h1>Page content with status banner</h1>
+      </div>
+    ),
+  },
+};

--- a/activity/src/components/Layout.tsx
+++ b/activity/src/components/Layout.tsx
@@ -3,10 +3,9 @@ import { StatusMessage } from './StatusMessage';
 
 interface LayoutProps {
   children: ReactNode;
-  onNavigateHome: () => void;
 }
 
-export function Layout({ children, onNavigateHome: _onNavigateHome }: LayoutProps) {
+export function Layout({ children }: LayoutProps) {
   return (
     <div id="app">
       <StatusMessage />

--- a/activity/src/components/MobilePlayerDrawer.tsx
+++ b/activity/src/components/MobilePlayerDrawer.tsx
@@ -1,18 +1,11 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { PlayerCard } from './PlayerCard';
-import { getPrimaryRole } from '../lib/roles';
+import { getPrimaryRole, ROLE_LABELS } from '../lib/roles';
 import type { WoWPlayer } from '../types';
 
 interface MobilePlayerDrawerProps {
   player: WoWPlayer;
 }
-
-const ROLE_LABELS: Record<string, string> = {
-  tank: 'Tank',
-  healer: 'Healer',
-  ranged: 'Ranged',
-  melee: 'Melee',
-};
 
 export function MobilePlayerDrawer({ player }: MobilePlayerDrawerProps) {
   const [expanded, setExpanded] = useState(false);

--- a/activity/src/components/PlayerCard.tsx
+++ b/activity/src/components/PlayerCard.tsx
@@ -3,15 +3,7 @@ import { WoWPlayer } from '../types';
 import { CharacterHeader } from './CharacterHeader';
 import { Divider } from './ui';
 import { RoleEditor } from './RoleEditor';
-import { getPrimaryRole } from '../lib/roles';
-
-const ROLE_COLOR_MAP: Record<string, string> = {
-  tank: 'var(--color-tank)',
-  healer: 'var(--color-healer)',
-  ranged: 'var(--color-dps)',
-  melee: 'var(--color-dps)',
-  unassigned: 'var(--text-secondary)',
-};
+import { getPrimaryRole, getRoleColor } from '../lib/roles';
 
 interface PlayerCardProps {
   player: WoWPlayer;
@@ -29,8 +21,7 @@ export function PlayerCard({ player, className = '' }: PlayerCardProps) {
     setMediaUrl(player.mediaUrl ?? null);
   }, [playerId]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const primaryRole = getPrimaryRole(player);
-  const color = ROLE_COLOR_MAP[primaryRole] ?? ROLE_COLOR_MAP.unassigned;
+  const color = getRoleColor(getPrimaryRole(player));
 
   // Compute class name from in-game name or character lookup
   const classSubtitle = player.inGameName || undefined;

--- a/activity/src/components/PlayerChip.stories.tsx
+++ b/activity/src/components/PlayerChip.stories.tsx
@@ -1,58 +1,103 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { withStore } from '../../.storybook/decorators';
 import { PlayerChip } from './PlayerChip';
-import { mockPlayers } from '../lib/mockData';
 
 const meta = {
   title: 'Molecules/PlayerChip',
   component: PlayerChip,
-  decorators: [
-    withStore({
-      currentPlayerId: '100000000000000007',
-      channelData: {
-        channelId: 'vc-1',
-        channelName: 'Mythic+ Lobby',
-        guildId: 'demo-guild',
-        status: 'lobby',
-        players: mockPlayers,
-        groups: [],
-        claimedPlayers: ['100000000000000005'],
-        sittingOut: [],
-        isDebug: false,
-        createdAt: null,
-        lastActive: null,
-      },
-    }),
-  ],
+  args: {
+    onClick: () => {},
+  },
 } satisfies Meta<typeof PlayerChip>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-// Tank with brez - claimed
-export const Tank: Story = { args: { player: mockPlayers[4] } };
+export const Tank: Story = {
+  args: {
+    name: 'Valeria',
+    roleKey: 'tank',
+    roleLabel: 'Tank',
+    tags: [
+      { label: 'Tank', cssClass: 'tag-tank' },
+      { label: 'Brez', cssClass: 'tag-brez' },
+    ],
+    isReady: true,
+  },
+};
 
-// Healer with offspecs
-export const Healer: Story = { args: { player: mockPlayers[0] } };
+export const Healer: Story = {
+  args: {
+    name: 'Lumina',
+    roleKey: 'healer',
+    roleLabel: 'Healer',
+    tags: [
+      { label: 'Healer', cssClass: 'tag-healer' },
+      { label: 'Off Ranged', cssClass: 'tag-dps tag-offspec' },
+    ],
+    isReady: true,
+  },
+};
 
-// Ranged DPS with lust
-export const RangedDPS: Story = { args: { player: mockPlayers[1] } };
+export const RangedDPS: Story = {
+  args: {
+    name: 'Pyro',
+    roleKey: 'ranged',
+    roleLabel: 'Ranged',
+    tags: [
+      { label: 'Ranged', cssClass: 'tag-dps' },
+      { label: 'Lust', cssClass: 'tag-lust' },
+    ],
+    isReady: true,
+  },
+};
 
-// Melee DPS (plain)
-export const MeleeDPS: Story = { args: { player: mockPlayers[5] } };
+export const MeleeDPS: Story = {
+  args: {
+    name: 'Slasher',
+    roleKey: 'melee',
+    roleLabel: 'Melee',
+    tags: [{ label: 'Melee', cssClass: 'tag-dps' }],
+    isReady: true,
+  },
+};
 
-// Current user (highlighted)
-export const CurrentUser: Story = { args: { player: mockPlayers[6] } };
+export const Selected: Story = {
+  args: {
+    name: 'You',
+    roleKey: 'tank',
+    roleLabel: 'Tank',
+    tags: [{ label: 'Tank', cssClass: 'tag-tank' }],
+    isReady: true,
+    isSelected: true,
+  },
+};
 
-// Unassigned player
+export const SittingOut: Story = {
+  args: {
+    name: 'Afker',
+    roleKey: 'healer',
+    roleLabel: 'Healer',
+    tags: [{ label: 'Healer', cssClass: 'tag-healer' }],
+    isSittingOut: true,
+  },
+};
+
+export const NotReady: Story = {
+  args: {
+    name: 'HasRoleNoName',
+    roleKey: 'tank',
+    roleLabel: 'Tank',
+    tags: [{ label: 'Tank', cssClass: 'tag-tank' }],
+    isReady: false,
+  },
+};
+
 export const Unassigned: Story = {
   args: {
-    player: {
-      name: 'NewPlayer',
-      discordId: '100000000000000099',
-      mainRole: null,
-      offspecs: [],
-      utilities: [],
-    },
+    name: 'NewPlayer',
+    roleKey: 'unassigned',
+    roleLabel: 'Unassigned',
+    tags: [{ label: 'No roles', cssClass: 'tag-unassigned' }],
+    isReady: false,
   },
 };

--- a/activity/src/components/PlayerChip.tsx
+++ b/activity/src/components/PlayerChip.tsx
@@ -30,6 +30,8 @@ export interface PlayerChipProps {
   isReady?: boolean;
   /** Click handler — fired from click or Enter/Space. */
   onClick?: () => void;
+  /** Accessible label for the chip. Defaults to "Edit {name} roles". */
+  ariaLabel?: string;
 }
 
 export function PlayerChip({
@@ -41,6 +43,7 @@ export function PlayerChip({
   isSittingOut = false,
   isReady = false,
   onClick,
+  ariaLabel,
 }: PlayerChipProps) {
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' || e.key === ' ') {
@@ -56,7 +59,7 @@ export function PlayerChip({
       onKeyDown={handleKeyDown}
       role="button"
       tabIndex={0}
-      aria-label={`Edit ${name} roles`}
+      aria-label={ariaLabel ?? `Edit ${name} roles`}
     >
       {isReady && <ReadyIcon />}
       {!isReady && !isSittingOut && <NotReadyIcon />}

--- a/activity/src/components/PlayerChip.tsx
+++ b/activity/src/components/PlayerChip.tsx
@@ -1,6 +1,4 @@
-import { WoWPlayer } from '../types';
-import { getPrimaryRole, formatRoleName, getRoleTags, isPlayerReady } from '../lib/roles';
-import { useAppStore } from '../store/store';
+import type { RoleTag } from '../lib/roles';
 
 const ReadyIcon = () => (
   <svg className="ready-check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
@@ -15,51 +13,61 @@ const NotReadyIcon = () => (
   </svg>
 );
 
-interface PlayerChipProps {
-  player: WoWPlayer;
+export interface PlayerChipProps {
+  /** Player display name. */
+  name: string;
+  /** Role key: 'tank' | 'healer' | 'ranged' | 'melee' | 'unassigned'. */
+  roleKey: string;
+  /** Human label for the role (used as aria/title). */
+  roleLabel: string;
+  /** Tags shown under the name (offspecs, utilities). */
+  tags?: RoleTag[];
+  /** Player is currently selected in the UI. */
+  isSelected?: boolean;
+  /** Player is sitting out this round. */
+  isSittingOut?: boolean;
+  /** Player is ready to spin (has role + WoW name). */
+  isReady?: boolean;
+  /** Click handler — fired from click or Enter/Space. */
+  onClick?: () => void;
 }
 
-export function PlayerChip({ player }: PlayerChipProps) {
-  const sittingOut = useAppStore((s) => s.channelData?.sittingOut) ?? [];
-  const roleKey = getPrimaryRole(player);
-  const roleName = formatRoleName(roleKey);
-  const tags = getRoleTags(player);
-
-  const activePlayer = useAppStore((s) => s.activePlayer);
-  const isSelected = activePlayer != null && player.discordId === activePlayer.discordId;
-  const isSittingOut = player.discordId != null && sittingOut.includes(player.discordId);
-  const ready = isPlayerReady(player);
-
-  const handleClick = () => {
-    useAppStore.getState().setActivePlayer(player);
-  };
-
+export function PlayerChip({
+  name,
+  roleKey,
+  roleLabel,
+  tags = [],
+  isSelected = false,
+  isSittingOut = false,
+  isReady = false,
+  onClick,
+}: PlayerChipProps) {
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
-      handleClick();
+      onClick?.();
     }
   };
 
   return (
     <div
-      className={`player-chip${isSelected ? ' is-selected' : ''}${isSittingOut ? ' sitting-out' : ''}${!ready && !isSittingOut ? ' not-ready' : ''}`}
-      onClick={handleClick}
+      className={`player-chip${isSelected ? ' is-selected' : ''}${isSittingOut ? ' sitting-out' : ''}${!isReady && !isSittingOut ? ' not-ready' : ''}`}
+      onClick={onClick}
       onKeyDown={handleKeyDown}
       role="button"
       tabIndex={0}
-      aria-label={`Edit ${player.name} roles`}
+      aria-label={`Edit ${name} roles`}
     >
-      {ready && <ReadyIcon />}
-      {!ready && !isSittingOut && <NotReadyIcon />}
+      {isReady && <ReadyIcon />}
+      {!isReady && !isSittingOut && <NotReadyIcon />}
       <div className="chip-header">
         <span
           className={`role-dot ${roleKey}`}
           role="img"
-          aria-label={roleName}
-          title={roleName}
+          aria-label={roleLabel}
+          title={roleLabel}
         />
-        <span>{player.name}</span>
+        <span>{name}</span>
       </div>
       {tags.length > 0 && (
         <div className="chip-tags">

--- a/activity/src/components/RoleEditor.stories.tsx
+++ b/activity/src/components/RoleEditor.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { withStore } from '../../.storybook/decorators';
+import { RoleEditor } from './RoleEditor';
+import { mockPlayers, mockChannelData } from '../lib/mockData';
+
+const meta = {
+  title: 'Organisms/RoleEditor',
+  component: RoleEditor,
+  parameters: { layout: 'padded' },
+  decorators: [
+    withStore({
+      currentPlayerId: '100000000000000007',
+      channelData: mockChannelData,
+    }),
+    (Story) => <div style={{ maxWidth: 420 }}><Story /></div>,
+  ],
+} satisfies Meta<typeof RoleEditor>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const CurrentUser: Story = { args: { player: mockPlayers[6] } };
+
+export const TankWithOffspecs: Story = { args: { player: mockPlayers[4] } };
+
+export const Unassigned: Story = {
+  args: {
+    player: {
+      name: 'NewPlayer',
+      discordId: '100000000000000099',
+      mainRole: null,
+      offspecs: [],
+      utilities: [],
+    },
+  },
+};
+
+export const HideSitOut: Story = {
+  args: { player: mockPlayers[6], hideSitOut: true },
+};

--- a/activity/src/components/RoleEditor.tsx
+++ b/activity/src/components/RoleEditor.tsx
@@ -14,6 +14,7 @@ import {
   type RoleButtonDef,
 } from '../lib/roles';
 import type { RaiderioCharacterResult } from '../services/raiderioService';
+import { reportError } from '../lib/sentry';
 
 interface RoleEditorProps {
   player: WoWPlayer;
@@ -70,7 +71,7 @@ export function RoleEditor({ player, onMediaUrlChange, hideSitOut }: RoleEditorP
           localStorage.setItem(`wheelson-player-${guildId ?? 'unknown'}`, player.discordId!);
         }
       } catch (err) {
-        console.error('[Wheelson] Auto-save failed:', err);
+        reportError(err, { tag: 'RoleEditor.autoSave' });
       }
     }, 500);
   }, [player.discordId, player.name, service]);

--- a/activity/src/components/SpinWarningDialog.stories.tsx
+++ b/activity/src/components/SpinWarningDialog.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { SpinWarningDialog } from './SpinWarningDialog';
+import { mockPlayers } from '../lib/mockData';
+
+const meta = {
+  title: 'Organisms/SpinWarningDialog',
+  component: SpinWarningDialog,
+  parameters: { layout: 'fullscreen' },
+  args: {
+    onGoBack: () => {},
+    onSpinAnyway: () => {},
+  },
+} satisfies Meta<typeof SpinWarningDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const unassigned = {
+  name: 'NewPlayer',
+  discordId: '200000000000000001',
+  mainRole: null,
+  offspecs: [],
+  utilities: [],
+};
+const assignedNoName = { ...mockPlayers[1], inGameName: undefined };
+
+export const MissingRoleOnly: Story = {
+  args: { missingRole: [unassigned], missingNameOnly: [] },
+};
+
+export const MissingNameOnly: Story = {
+  args: { missingRole: [], missingNameOnly: [assignedNoName] },
+};
+
+export const Both: Story = {
+  args: {
+    missingRole: [unassigned],
+    missingNameOnly: [assignedNoName],
+  },
+};

--- a/activity/src/components/SpotlightCard.stories.tsx
+++ b/activity/src/components/SpotlightCard.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { withStore } from '../../.storybook/decorators';
+import { SpotlightCard } from './SpotlightCard';
+import { mockGroups } from '../lib/mockData';
+
+const meta = {
+  title: 'Organisms/SpotlightCard',
+  component: SpotlightCard,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    withStore({ currentPlayerId: '100000000000000007' }),
+    (Story) => (
+      <div style={{ padding: '4rem 2rem', minHeight: '50vh', display: 'flex', justifyContent: 'center' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof SpotlightCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Visible: Story = {
+  args: { group: mockGroups[0], index: 0, visible: true },
+};
+
+export const MyGroup: Story = {
+  args: { group: mockGroups[1], index: 1, visible: true },
+};
+
+export const Hidden: Story = {
+  args: { group: mockGroups[0], index: 0, visible: false },
+};
+
+export const Exiting: Story = {
+  args: { group: mockGroups[0], index: 0, visible: true, exit: true },
+};
+
+export const CustomLabel: Story = {
+  args: { group: mockGroups[0], index: 0, visible: true, label: "Final Group" },
+};

--- a/activity/src/components/SpotlightCard.tsx
+++ b/activity/src/components/SpotlightCard.tsx
@@ -1,6 +1,7 @@
 import { WoWGroup, WoWPlayer } from '../types';
 import { useAppStore } from '../store/store';
 import { utilityIcons } from '../lib/roles';
+import { RoleRow } from './ui';
 import { SpotlightPortraits } from './SpotlightPortraits';
 
 interface SpotlightCardProps {
@@ -9,28 +10,6 @@ interface SpotlightCardProps {
   visible: boolean;
   exit?: boolean;
   label?: string;
-}
-
-function SpotlightRoleRow({ color, roleLabel, name, player, isOffspec }: {
-  color: string;
-  roleLabel: string;
-  name: string;
-  player?: WoWPlayer | null;
-  isOffspec?: boolean;
-}) {
-  return (
-    <div className="spotlight-role">
-      <span
-        className={`role-indicator ${roleLabel.toLowerCase()}${isOffspec ? ' offspec' : ''}`}
-        style={isOffspec ? { borderColor: color } : { background: color }}
-        role="img"
-        aria-label={`${roleLabel}${isOffspec ? ' (offspec)' : ''}`}
-        title={`${roleLabel}${isOffspec ? ' (offspec)' : ''}`}
-      />
-      <span className="role-label">{roleLabel}</span>
-      <span className="role-name">{name}{utilityIcons(player)}</span>
-    </div>
-  );
 }
 
 export function SpotlightCard({ group, index, visible, exit = false, label }: SpotlightCardProps) {
@@ -47,13 +26,35 @@ export function SpotlightCard({ group, index, visible, exit = false, label }: Sp
           {label ?? (group.tank ? `${group.tank.name}'s Group` : `Group ${index + 1}`)}
         </h3>
         {group.tank && (
-          <SpotlightRoleRow color="var(--color-tank)" roleLabel="Tank" name={group.tank.name} player={group.tank} isOffspec={group.tank.mainRole !== 'tank'} />
+          <RoleRow
+            variant="spotlight"
+            color="var(--color-tank)"
+            roleLabel="Tank"
+            name={group.tank.name}
+            suffix={utilityIcons(group.tank)}
+            isOffspec={group.tank.mainRole !== 'tank'}
+          />
         )}
         {group.healer && (
-          <SpotlightRoleRow color="var(--color-healer)" roleLabel="Healer" name={group.healer.name} player={group.healer} isOffspec={group.healer.mainRole !== 'healer'} />
+          <RoleRow
+            variant="spotlight"
+            color="var(--color-healer)"
+            roleLabel="Healer"
+            name={group.healer.name}
+            suffix={utilityIcons(group.healer)}
+            isOffspec={group.healer.mainRole !== 'healer'}
+          />
         )}
         {group.dps.map((d) => (
-          <SpotlightRoleRow key={d.discordId || d.name} color="var(--color-dps)" roleLabel="DPS" name={d.name} player={d} isOffspec={d.mainRole !== null && d.mainRole !== 'ranged' && d.mainRole !== 'melee'} />
+          <RoleRow
+            key={d.discordId || d.name}
+            variant="spotlight"
+            color="var(--color-dps)"
+            roleLabel="DPS"
+            name={d.name}
+            suffix={utilityIcons(d)}
+            isOffspec={d.mainRole !== null && d.mainRole !== 'ranged' && d.mainRole !== 'melee'}
+          />
         ))}
       </div>
       <SpotlightPortraits players={rosterPlayers} />

--- a/activity/src/components/WheelsGrid.stories.tsx
+++ b/activity/src/components/WheelsGrid.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { WheelsGridComponent } from './WheelsGrid';
+import { mockPlayers } from '../lib/mockData';
+import { initPools } from '../lib/roles';
+
+const meta = {
+  title: 'Organisms/WheelsGrid',
+  component: WheelsGridComponent,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <div style={{ height: '100vh', background: 'var(--color-bg)', padding: '1rem' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof WheelsGridComponent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FullPool: Story = {
+  args: { pools: initPools(mockPlayers) },
+};
+
+export const Empty: Story = {
+  args: { pools: null },
+};
+
+export const MinimalPool: Story = {
+  args: { pools: initPools(mockPlayers.slice(0, 5)) },
+};

--- a/activity/src/components/ui/RoleRow.tsx
+++ b/activity/src/components/ui/RoleRow.tsx
@@ -5,6 +5,8 @@ interface RoleRowProps {
   name: string;
   /** CSS variable or color string for the role indicator. */
   color: string;
+  /** CSS class suffix for the role indicator ("tank", "healer", "dps"). Defaults to lowercased `roleLabel`. */
+  roleClass?: string;
   /** Whether the player is filling this slot as an offspec. */
   isOffspec?: boolean;
   /** Compact variant hides the role label text. */
@@ -19,6 +21,7 @@ export function RoleRow({
   roleLabel,
   name,
   color,
+  roleClass,
   isOffspec = false,
   compact = false,
   variant = 'card',
@@ -30,12 +33,13 @@ export function RoleRow({
       : compact
         ? 'compact-role'
         : 'group-role';
+  const indicatorClass = roleClass ?? roleLabel.toLowerCase();
   const ariaLabel = `${roleLabel}${isOffspec ? ' (offspec)' : ''}`;
 
   return (
     <div className={rowClass}>
       <span
-        className={`role-indicator ${roleLabel.toLowerCase()}${isOffspec ? ' offspec' : ''}`}
+        className={`role-indicator ${indicatorClass}${isOffspec ? ' offspec' : ''}`}
         style={isOffspec ? { borderColor: color } : { background: color }}
         role="img"
         aria-label={ariaLabel}

--- a/activity/src/components/ui/RoleRow.tsx
+++ b/activity/src/components/ui/RoleRow.tsx
@@ -1,0 +1,53 @@
+interface RoleRowProps {
+  /** Role label shown in the row ("Tank", "Healer", "DPS"). */
+  roleLabel: string;
+  /** Player name (may include utility icons via `suffix`). */
+  name: string;
+  /** CSS variable or color string for the role indicator. */
+  color: string;
+  /** Whether the player is filling this slot as an offspec. */
+  isOffspec?: boolean;
+  /** Compact variant hides the role label text. */
+  compact?: boolean;
+  /** Variant style: 'card' (default) or 'spotlight'. */
+  variant?: 'card' | 'spotlight';
+  /** Optional trailing content (e.g., utility icons). */
+  suffix?: string;
+}
+
+export function RoleRow({
+  roleLabel,
+  name,
+  color,
+  isOffspec = false,
+  compact = false,
+  variant = 'card',
+  suffix = '',
+}: RoleRowProps) {
+  const rowClass =
+    variant === 'spotlight'
+      ? 'spotlight-role'
+      : compact
+        ? 'compact-role'
+        : 'group-role';
+  const ariaLabel = `${roleLabel}${isOffspec ? ' (offspec)' : ''}`;
+
+  return (
+    <div className={rowClass}>
+      <span
+        className={`role-indicator ${roleLabel.toLowerCase()}${isOffspec ? ' offspec' : ''}`}
+        style={isOffspec ? { borderColor: color } : { background: color }}
+        role="img"
+        aria-label={ariaLabel}
+        title={ariaLabel}
+      />
+      {(variant === 'spotlight' || !compact) && (
+        <span className="role-label">{roleLabel}</span>
+      )}
+      <span className="role-name">
+        {name}
+        {suffix}
+      </span>
+    </div>
+  );
+}

--- a/activity/src/components/ui/index.ts
+++ b/activity/src/components/ui/index.ts
@@ -10,3 +10,4 @@ export { MultiPicker } from './MultiPicker';
 export type { PickerOption } from './MultiPicker';
 export { RoleSectionHeader } from './RoleSectionHeader';
 export { CharacterSearchInput } from './CharacterSearchInput';
+export { RoleRow } from './RoleRow';

--- a/activity/src/discordSdk.ts
+++ b/activity/src/discordSdk.ts
@@ -1,4 +1,5 @@
 import { DiscordSDK, patchUrlMappings } from '@discord/embedded-app-sdk';
+import { reportError } from './lib/sentry';
 
 export interface DiscordContext {
   guildId: string;
@@ -98,7 +99,7 @@ export async function setupDiscordSdk(): Promise<DiscordContext | null> {
       channelId: discordSdk.channelId,
     };
   } catch (e) {
-    console.error('Discord SDK init failed', e);
+    reportError(e, { tag: 'discordSdk.init' });
     return null;
   }
 }

--- a/activity/src/hooks/useAffixes.ts
+++ b/activity/src/hooks/useAffixes.ts
@@ -4,6 +4,7 @@ import { db } from '../firebase';
 import { useAppStore } from '../store/store';
 import { STATIC_AFFIXES, resolveAffixDisplay } from '@mythicplus/shared';
 import type { AffixDisplay } from '@mythicplus/shared';
+import { reportError } from '../lib/sentry';
 
 interface AffixData {
   period: number;
@@ -37,7 +38,7 @@ export function useAffixes(): AffixData | null {
           setData({ period: 0, region: 'us', affixes: STATIC_AFFIXES });
         }
       },
-      (error) => console.error('[Wheelson] Failed to load affixes:', error),
+      (error) => reportError(error, { tag: 'useAffixes.onSnapshot' }),
     );
     return unsub;
   }, [isDemoMode]);

--- a/activity/src/lib/roles.ts
+++ b/activity/src/lib/roles.ts
@@ -46,6 +46,28 @@ export function formatRoleName(role: string): string {
   return role.charAt(0).toUpperCase() + role.slice(1).toLowerCase();
 }
 
+/** CSS variable color for a role key (including 'unassigned'). */
+export const ROLE_COLOR_MAP: Record<string, string> = {
+  tank: 'var(--color-tank)',
+  healer: 'var(--color-healer)',
+  ranged: 'var(--color-dps)',
+  melee: 'var(--color-dps)',
+  unassigned: 'var(--text-secondary)',
+};
+
+export function getRoleColor(role: string): string {
+  return ROLE_COLOR_MAP[role] ?? ROLE_COLOR_MAP.unassigned;
+}
+
+/** Display labels keyed by role. */
+export const ROLE_LABELS: Record<string, string> = {
+  tank: 'Tank',
+  healer: 'Healer',
+  ranged: 'Ranged',
+  melee: 'Melee',
+  unassigned: 'Unassigned',
+};
+
 export function utilityIcons(player?: WoWPlayer | null): string {
   if (!player) return '';
   let icons = '';

--- a/activity/src/lib/rolesHelpers.test.ts
+++ b/activity/src/lib/rolesHelpers.test.ts
@@ -12,6 +12,7 @@ import {
   playerRolesToStringArray,
   roleStringsToPlayerFields,
   utilityIcons,
+  computeToggledRoles,
 } from './roles';
 import type { WoWPlayer } from '../types';
 
@@ -145,6 +146,42 @@ describe('playerRolesToStringArray / roleStringsToPlayerFields', () => {
     expect(fields.mainRole).toBeNull();
     expect(fields.offspecs).toEqual([]);
     expect(fields.utilities).toEqual([]);
+  });
+});
+
+describe('computeToggledRoles', () => {
+  it('removes a role that is already active', () => {
+    const next = computeToggledRoles(new Set(['Tank', 'Brez']), 'Tank', true);
+    expect(next.has('Tank')).toBe(false);
+    expect(next.has('Brez')).toBe(true);
+  });
+
+  it('switching main spec: swaps old main into offspec when new main was an offspec', () => {
+    // Current: main=Tank, offspec=Healer. Toggle Healer as main.
+    const next = computeToggledRoles(new Set(['Tank', 'Healer Offspec']), 'Healer', true);
+    expect(next.has('Healer')).toBe(true);
+    expect(next.has('Tank')).toBe(false);
+    expect(next.has('Healer Offspec')).toBe(false);
+    expect(next.has('Tank Offspec')).toBe(true);
+  });
+
+  it('switching main spec without matching offspec: just replaces', () => {
+    const next = computeToggledRoles(new Set(['Tank']), 'Healer', true);
+    expect(next.has('Healer')).toBe(true);
+    expect(next.has('Tank')).toBe(false);
+    expect(next.has('Tank Offspec')).toBe(false);
+  });
+
+  it('adding an offspec matching current main is a no-op', () => {
+    const prev = new Set(['Tank']);
+    const next = computeToggledRoles(prev, 'Tank Offspec', false);
+    expect(Array.from(next).sort()).toEqual(['Tank']);
+  });
+
+  it('adds offspec when it does not match current main', () => {
+    const next = computeToggledRoles(new Set(['Tank']), 'Healer Offspec', false);
+    expect(next.has('Tank')).toBe(true);
+    expect(next.has('Healer Offspec')).toBe(true);
   });
 });
 

--- a/activity/src/lib/rolesHelpers.test.ts
+++ b/activity/src/lib/rolesHelpers.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getPrimaryRole,
+  formatRoleName,
+  getRoleColor,
+  ROLE_LABELS,
+  hasAnyRole,
+  getRoleTags,
+  isPlayerReady,
+  getReadyCount,
+  categorizeUnreadyPlayers,
+  playerRolesToStringArray,
+  roleStringsToPlayerFields,
+  utilityIcons,
+} from './roles';
+import type { WoWPlayer } from '../types';
+
+const player = (overrides: Partial<WoWPlayer> = {}): WoWPlayer => ({
+  name: 'Test',
+  discordId: 'd1',
+  mainRole: null,
+  offspecs: [],
+  utilities: [],
+  ...overrides,
+});
+
+describe('getPrimaryRole', () => {
+  it('returns mainRole when set', () => {
+    expect(getPrimaryRole(player({ mainRole: 'tank' }))).toBe('tank');
+  });
+  it('returns unassigned when null', () => {
+    expect(getPrimaryRole(player())).toBe('unassigned');
+  });
+});
+
+describe('formatRoleName', () => {
+  it('capitalizes known roles', () => {
+    expect(formatRoleName('tank')).toBe('Tank');
+    expect(formatRoleName('melee')).toBe('Melee');
+  });
+  it('handles unassigned', () => {
+    expect(formatRoleName('unassigned')).toBe('Unassigned');
+  });
+});
+
+describe('getRoleColor', () => {
+  it('returns a color var for every known role', () => {
+    expect(getRoleColor('tank')).toBe('var(--color-tank)');
+    expect(getRoleColor('healer')).toBe('var(--color-healer)');
+    expect(getRoleColor('ranged')).toBe('var(--color-dps)');
+    expect(getRoleColor('melee')).toBe('var(--color-dps)');
+  });
+  it('falls back to unassigned color for unknown', () => {
+    expect(getRoleColor('bogus')).toBe('var(--text-secondary)');
+  });
+});
+
+describe('ROLE_LABELS', () => {
+  it('has entries for all primary roles', () => {
+    for (const r of ['tank', 'healer', 'ranged', 'melee', 'unassigned']) {
+      expect(ROLE_LABELS[r]).toBeTruthy();
+    }
+  });
+});
+
+describe('hasAnyRole', () => {
+  it('is false for an empty player', () => {
+    expect(hasAnyRole(player())).toBe(false);
+  });
+  it('is true with main role', () => {
+    expect(hasAnyRole(player({ mainRole: 'tank' }))).toBe(true);
+  });
+  it('is true with only offspec', () => {
+    expect(hasAnyRole(player({ offspecs: ['healer'] }))).toBe(true);
+  });
+});
+
+describe('getRoleTags', () => {
+  it('returns No roles tag when empty', () => {
+    const tags = getRoleTags(player());
+    expect(tags).toEqual([{ label: 'No roles', cssClass: 'tag-unassigned' }]);
+  });
+  it('omits offspec tag when it matches the main', () => {
+    const tags = getRoleTags(player({ mainRole: 'tank', offspecs: ['tank'] }));
+    expect(tags.find(t => t.label === 'Tank' && t.cssClass.includes('offspec'))).toBeUndefined();
+  });
+  it('includes utility tags', () => {
+    const tags = getRoleTags(player({ mainRole: 'healer', utilities: ['brez', 'lust'] }));
+    const labels = tags.map(t => t.label);
+    expect(labels).toContain('Brez');
+    expect(labels).toContain('Lust');
+  });
+});
+
+describe('isPlayerReady', () => {
+  it('needs both inGameName and mainRole', () => {
+    expect(isPlayerReady(player())).toBe(false);
+    expect(isPlayerReady(player({ mainRole: 'tank' }))).toBe(false);
+    expect(isPlayerReady(player({ inGameName: 'Foo' }))).toBe(false);
+    expect(isPlayerReady(player({ inGameName: 'Foo', mainRole: 'tank' }))).toBe(true);
+  });
+});
+
+describe('getReadyCount', () => {
+  it('excludes sitting-out players from total', () => {
+    const players = [
+      player({ discordId: '1', inGameName: 'A', mainRole: 'tank' }),
+      player({ discordId: '2', inGameName: 'B', mainRole: 'healer' }),
+      player({ discordId: '3', mainRole: null }),
+    ];
+    expect(getReadyCount(players, ['3'])).toEqual({ ready: 2, total: 2 });
+    expect(getReadyCount(players, [])).toEqual({ ready: 2, total: 3 });
+  });
+});
+
+describe('categorizeUnreadyPlayers', () => {
+  it('separates missing-role from missing-name', () => {
+    const players = [
+      player({ discordId: '1', inGameName: 'A', mainRole: 'tank' }),
+      player({ discordId: '2', mainRole: 'healer' }),
+      player({ discordId: '3', mainRole: null }),
+    ];
+    const result = categorizeUnreadyPlayers(players, []);
+    expect(result.missingRole.map(p => p.discordId)).toEqual(['3']);
+    expect(result.missingNameOnly.map(p => p.discordId)).toEqual(['2']);
+  });
+  it('ignores sitting-out players', () => {
+    const players = [player({ discordId: '3', mainRole: null })];
+    const result = categorizeUnreadyPlayers(players, ['3']);
+    expect(result.missingRole).toEqual([]);
+  });
+});
+
+describe('playerRolesToStringArray / roleStringsToPlayerFields', () => {
+  it('round-trips a tank with offspecs and utilities', () => {
+    const p = player({ mainRole: 'tank', offspecs: ['healer', 'melee'], utilities: ['brez'] });
+    const strings = playerRolesToStringArray(p);
+    const fields = roleStringsToPlayerFields(strings);
+    expect(fields.mainRole).toBe('tank');
+    expect(fields.offspecs.sort()).toEqual(['healer', 'melee']);
+    expect(fields.utilities).toEqual(['brez']);
+  });
+  it('handles unassigned player', () => {
+    const fields = roleStringsToPlayerFields([]);
+    expect(fields.mainRole).toBeNull();
+    expect(fields.offspecs).toEqual([]);
+    expect(fields.utilities).toEqual([]);
+  });
+});
+
+describe('utilityIcons', () => {
+  it('returns empty when no player', () => {
+    expect(utilityIcons(null)).toBe('');
+    expect(utilityIcons(undefined)).toBe('');
+  });
+  it('includes brez and lust glyphs', () => {
+    const icons = utilityIcons(player({ utilities: ['brez', 'lust'] }));
+    expect(icons).toMatch(/⚰/);
+    expect(icons).toMatch(/🎺/);
+  });
+});

--- a/activity/src/lib/routing.test.ts
+++ b/activity/src/lib/routing.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { statusToView, routeToView, viewToRoute } from './routing';
+
+describe('statusToView', () => {
+  it('maps lobby/request_spin to lobby', () => {
+    expect(statusToView('lobby')).toBe('lobby');
+    expect(statusToView('request_spin')).toBe('lobby');
+  });
+  it('maps spinning to wheels', () => {
+    expect(statusToView('spinning')).toBe('wheels');
+  });
+  it('maps completed to results', () => {
+    expect(statusToView('completed')).toBe('results');
+  });
+  it('falls back to lobby and warns on unknown status', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(statusToView('bogus')).toBe('lobby');
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+
+describe('routeToView', () => {
+  it('returns home for empty hash', () => {
+    expect(routeToView('')).toEqual({ view: 'home', guildId: null });
+    expect(routeToView('#/')).toEqual({ view: 'home', guildId: null });
+  });
+  it('parses guild views', () => {
+    expect(routeToView('#/guild/abc-123/lobby')).toEqual({ view: 'lobby', guildId: 'abc-123' });
+    expect(routeToView('#/guild/g1/wheels')).toEqual({ view: 'wheels', guildId: 'g1' });
+    expect(routeToView('#/guild/g1/results')).toEqual({ view: 'results', guildId: 'g1' });
+  });
+  it('returns home for malformed paths', () => {
+    expect(routeToView('#/guild//lobby')).toEqual({ view: 'home', guildId: null });
+    expect(routeToView('#/guild/g1/unknown')).toEqual({ view: 'home', guildId: null });
+    expect(routeToView('#garbage')).toEqual({ view: 'home', guildId: null });
+  });
+});
+
+describe('viewToRoute', () => {
+  it('returns root for home', () => {
+    expect(viewToRoute('home')).toBe('#/');
+    expect(viewToRoute('home', 'g1')).toBe('#/');
+  });
+  it('returns root when guild missing', () => {
+    expect(viewToRoute('lobby', null)).toBe('#/');
+    expect(viewToRoute('lobby')).toBe('#/');
+  });
+  it('builds guild routes', () => {
+    expect(viewToRoute('lobby', 'g1')).toBe('#/guild/g1/lobby');
+    expect(viewToRoute('wheels', 'g1')).toBe('#/guild/g1/wheels');
+  });
+  it('round-trips through routeToView', () => {
+    const cases: Array<['lobby' | 'wheels' | 'results' | 'channels', string]> = [
+      ['lobby', 'g1'],
+      ['wheels', 'guild-2'],
+      ['results', 'gg'],
+      ['channels', 'xyz'],
+    ];
+    for (const [view, guild] of cases) {
+      const route = viewToRoute(view, guild);
+      expect(routeToView(route)).toEqual({ view, guildId: guild });
+    }
+  });
+});

--- a/activity/src/views/ChannelsView.tsx
+++ b/activity/src/views/ChannelsView.tsx
@@ -27,7 +27,7 @@ export function ChannelsView({ onNavigate }: ChannelsViewProps) {
   useEffect(() => {
     if (!hasAutoRefreshed.current && guildData && channels.length === 0 && currentGuildId) {
       hasAutoRefreshed.current = true;
-      service.refreshChannels(currentGuildId).catch((err) => console.error('[Wheelson] Auto-refresh failed:', err));
+      service.refreshChannels(currentGuildId).catch((err) => reportError(err, { tag: 'ChannelsView.autoRefresh' }));
     }
   }, [guildData, channels.length, currentGuildId, service]);
 
@@ -55,7 +55,7 @@ export function ChannelsView({ onNavigate }: ChannelsViewProps) {
     try {
       await service.selectChannel(channelId, channelName, currentGuildId || '');
     } catch (err) {
-      console.error('[Wheelson] Failed to create channel doc:', err);
+      reportError(err, { tag: 'ChannelsView.selectChannel' });
       store.setStatusMessage('Failed to start session. Please try again.');
       return;
     }

--- a/activity/src/views/LobbyView.tsx
+++ b/activity/src/views/LobbyView.tsx
@@ -9,7 +9,7 @@ import { SpinWarningDialog } from '../components/SpinWarningDialog';
 import { HeaderBar } from '../components/HeaderBar';
 import { PrimaryCTA, RoleSectionHeader } from '../components/ui';
 import { CollapsibleRoleSection } from '../components/CollapsibleRoleSection';
-import { getPrimaryRole, hasAnyRole, getReadyCount, categorizeUnreadyPlayers } from '../lib/roles';
+import { getPrimaryRole, hasAnyRole, getReadyCount, categorizeUnreadyPlayers, formatRoleName, getRoleTags, isPlayerReady } from '../lib/roles';
 import { useIsMobileLobby } from '../hooks/useMediaQuery';
 import { MobilePlayerDrawer } from '../components/MobilePlayerDrawer';
 
@@ -89,22 +89,35 @@ export function LobbyView({ onNavigate }: LobbyViewProps) {
   const allReady = ready === total && total > 0;
   const readyText = `${ready}/${total} Ready`;
 
-  const handleChipClick = (e: React.MouseEvent, player: typeof players[number]) => {
+  const activePlayer = useAppStore((s) => s.activePlayer);
+
+  const handleChipClick = (player: typeof players[number]) => {
     if (player.discordId === currentPlayerId) {
       useAppStore.getState().setActivePlayer(player);
     } else {
-      // Prevent PlayerChip's internal handleClick from setting activePlayer
-      e.stopPropagation();
       useAppStore.getState().setActivePlayer(null);
       setEditingPlayer(player);
     }
   };
 
-  const renderChip = (p: typeof players[number]) => (
-    <div key={p.discordId || p.name} onClickCapture={(e) => handleChipClick(e, p)}>
-      <PlayerChip player={p} />
-    </div>
-  );
+  const renderChip = (p: typeof players[number]) => {
+    const roleKey = getPrimaryRole(p);
+    const isSelected = activePlayer != null && p.discordId === activePlayer.discordId;
+    const isSittingOut = p.discordId != null && sittingOut.includes(p.discordId);
+    return (
+      <PlayerChip
+        key={p.discordId || p.name}
+        name={p.name}
+        roleKey={roleKey}
+        roleLabel={formatRoleName(roleKey)}
+        tags={getRoleTags(p)}
+        isSelected={isSelected}
+        isSittingOut={isSittingOut}
+        isReady={isPlayerReady(p)}
+        onClick={() => handleChipClick(p)}
+      />
+    );
+  };
 
   const playerCountText = players.length === 0
     ? '0 players'

--- a/activity/src/views/LobbyView.tsx
+++ b/activity/src/views/LobbyView.tsx
@@ -89,6 +89,11 @@ export function LobbyView({ onNavigate }: LobbyViewProps) {
   const allReady = ready === total && total > 0;
   const readyText = `${ready}/${total} Ready`;
 
+  const unreadyBreakdown = useMemo(
+    () => categorizeUnreadyPlayers(players, sittingOut),
+    [players, sittingOut],
+  );
+
   const activePlayer = useAppStore((s) => s.activePlayer);
 
   const handleChipClick = (player: typeof players[number]) => {
@@ -104,6 +109,7 @@ export function LobbyView({ onNavigate }: LobbyViewProps) {
     const roleKey = getPrimaryRole(p);
     const isSelected = activePlayer != null && p.discordId === activePlayer.discordId;
     const isSittingOut = p.discordId != null && sittingOut.includes(p.discordId);
+    const isSelf = p.discordId === currentPlayerId;
     return (
       <PlayerChip
         key={p.discordId || p.name}
@@ -115,6 +121,7 @@ export function LobbyView({ onNavigate }: LobbyViewProps) {
         isSittingOut={isSittingOut}
         isReady={isPlayerReady(p)}
         onClick={() => handleChipClick(p)}
+        ariaLabel={isSelf ? `View ${p.name} details` : `Edit ${p.name} roles`}
       />
     );
   };
@@ -267,17 +274,14 @@ export function LobbyView({ onNavigate }: LobbyViewProps) {
           onClose={() => setEditingPlayer(null)}
         />
       )}
-      {showSpinWarning && (() => {
-        const { missingRole, missingNameOnly } = categorizeUnreadyPlayers(players, sittingOut);
-        return (
-          <SpinWarningDialog
-            missingRole={missingRole}
-            missingNameOnly={missingNameOnly}
-            onGoBack={() => setShowSpinWarning(false)}
-            onSpinAnyway={doSpin}
-          />
-        );
-      })()}
+      {showSpinWarning && (
+        <SpinWarningDialog
+          missingRole={unreadyBreakdown.missingRole}
+          missingNameOnly={unreadyBreakdown.missingNameOnly}
+          onGoBack={() => setShowSpinWarning(false)}
+          onSpinAnyway={doSpin}
+        />
+      )}
     </div>
   );
 }

--- a/activity/src/views/ResultsView.tsx
+++ b/activity/src/views/ResultsView.tsx
@@ -90,7 +90,7 @@ export function ResultsView({ onNavigate }: ResultsViewProps) {
       await service.newRound();
       onNavigate('lobby');
     } catch (err) {
-      console.error('[Wheelson] Failed to start new round:', err);
+      reportError(err, { tag: 'ResultsView.newRound' });
       useAppStore.getState().setStatusMessage('Failed to start new round. Please refresh.');
     }
   };
@@ -106,7 +106,7 @@ export function ResultsView({ onNavigate }: ResultsViewProps) {
       setReportTitle('');
       setReportDescription('');
     } catch (err) {
-      console.error('[Wheelson] Failed to report bad group:', err);
+      reportError(err, { tag: 'ResultsView.reportBadGroup' });
       useAppStore.getState().setStatusMessage('Failed to submit report. Please try again.');
     } finally {
       setReportSubmitting(false);

--- a/activity/src/views/WheelsView.tsx
+++ b/activity/src/views/WheelsView.tsx
@@ -14,6 +14,7 @@ import { isCompleteGroup } from '../store/types';
 import { initPools } from '../lib/roles';
 import { WheelEntry } from '../types';
 import { audio } from '../lib/audio';
+import { reportError } from '../lib/sentry';
 import {
   delay,
   CAROUSEL_SPIN_DURATION, CAROUSEL_ADVANCE_DELAY, GRID_SPIN_DURATION,
@@ -305,7 +306,7 @@ export function WheelsView({ onNavigate }: WheelsViewProps) {
     try {
       await service.finishSequence();
     } catch (err) {
-      console.error('[Wheelson] Failed to finish sequence:', err);
+      reportError(err, { tag: 'WheelsView.finishSequence' });
     }
   }, [spinOneGroupGrid, spinOneGroupCarousel, updateProgress, onNavigate, service]);
 
@@ -318,7 +319,7 @@ export function WheelsView({ onNavigate }: WheelsViewProps) {
 
     if (store.isDemoMode) {
       runAutoAdvanceLoop().catch((err) => {
-        console.error('[Wheelson] Demo advance failed:', err);
+        reportError(err, { tag: 'WheelsView.demoAdvance' });
         setShowSpinBtn(true);
         setSpinBtnDisabled(false);
       });
@@ -328,7 +329,7 @@ export function WheelsView({ onNavigate }: WheelsViewProps) {
     try {
       await service.revealAllGroups();
     } catch (err) {
-      console.error('[Wheelson] Failed to reveal groups:', err);
+      reportError(err, { tag: 'WheelsView.revealAllGroups' });
       setWheelStatus('Failed to spin. Please try again.');
       setShowSpinBtn(true);
       setSpinBtnDisabled(false);


### PR DESCRIPTION
## Summary

Overnight deep-review pass on the activity frontend. Focus on consistency, reusable primitives, test coverage, and observability.

### Code dedup & primitive APIs
- Centralized `ROLE_COLOR_MAP` / `ROLE_LABELS` / `getRoleColor()` in `lib/roles.ts` (was duplicated across 3 components).
- Extracted shared `RoleRow` primitive (`components/ui/RoleRow.tsx`) used by both `GroupCard` and `SpotlightCard` via a `variant` prop — removed the duplicated `SpotlightRoleRow` and card-local `RoleRow`.
- Refactored `PlayerChip` to a primitive-prop API: `name`, `roleKey`, `roleLabel`, `tags`, `isSelected`, `isSittingOut`, `isReady`, `onClick`. No longer imports `WoWPlayer` or reads from the store — makes the component trivially storybook-able and decouples rendering from domain logic. `LobbyView` wires the store data in at the call site.
- Removed unused `onNavigateHome` prop on `Layout`.

### Sentry / observability
Routed all remaining `console.error` calls through `reportError(err, { tag })` so production errors surface in Sentry:
- `ChannelsView` (autoRefresh, selectChannel)
- `ResultsView` (newRound, reportBadGroup)
- `WheelsView` (finishSequence, demoAdvance, revealAllGroups)
- `RoleEditor` (autoSave)
- `useAffixes` (onSnapshot)
- `discordSdk` (init)

### Test & Storybook coverage
- New unit tests: `lib/roles.test.ts` (role helpers, utility icons, round-trips), `lib/routing.test.ts` (statusToView / routeToView / viewToRoute incl. malformed-input fallbacks).
- New stories covering previously-uncovered components: `CollapsibleRoleSection`, `ConfirmBackDialog`, `SpinWarningDialog`, `EditPlayerModal`, `RoleEditor`, `SpotlightCard`, `Layout`, `WheelsGrid`.

### Tradeoffs
- `PlayerChip` now takes more props at call sites instead of a single `WoWPlayer`. This is intentional: the parent view owns the player→chip projection, keeping the chip itself pure and easy to test/story. Only `LobbyView` calls it, so the extra verbosity is localized.
- `RoleRow` unifies card and spotlight variants via a `variant` discriminator rather than two separate components. Fewer files, shared changes land once, but the component is slightly busier. Judged worth it since the rows are structurally identical.

## Test plan
- [x] `./scripts/verify-ts.sh` — backend lint + typecheck + 228 tests pass
- [x] `./scripts/verify-activity.sh` — frontend typecheck + 156 Playwright visual tests pass (no snapshot regressions)
- [ ] Smoke-test activity flow in Discord after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)