### PR TITLE
fix: stop character search input flashing on suggestion click

### DIFF
--- a/activity/src/components/RoleEditor.tsx
+++ b/activity/src/components/RoleEditor.tsx
@@ -103,9 +103,16 @@ export function RoleEditor({ player, onMediaUrlChange, hideSitOut }: RoleEditorP
 
     const character = await lookup(result.name, result.realmSlug, result.region);
     if (character) {
-      setInGameName(character.name);
-      nameRef.current = character.name;
       if (character.mediaUrl) onMediaUrlChange?.(character.mediaUrl);
+
+      // The onChange fired by CharacterSearchInput already put "Name-Realm" into
+      // the input and nameRef. Cancel the pending debounced save so we don't
+      // race with our explicit saveRoles below.
+      if (saveTimerRef.current) {
+        clearTimeout(saveTimerRef.current);
+        saveTimerRef.current = null;
+      }
+      const nameToSave = nameRef.current;
 
       // Save linkedCharacter + mediaUrl BEFORE saveRoles so the bot's
       // refreshPlayers cycle reads the mediaUrl from the preference doc.
@@ -129,9 +136,9 @@ export function RoleEditor({ player, onMediaUrlChange, hideSitOut }: RoleEditorP
         const roleSet = new Set(roles);
         setSelectedRoles(roleSet);
         rolesRef.current = roleSet;
-        await service.saveRoles(player.discordId, player.name, roles, character.name);
+        await service.saveRoles(player.discordId, player.name, roles, nameToSave);
       } else {
-        await service.saveRoles(player.discordId, player.name, Array.from(selectedRoles), character.name);
+        await service.saveRoles(player.discordId, player.name, Array.from(selectedRoles), nameToSave);
       }
     }
   }, [lookupLoading, player, lookup, selectedRoles, service, onMediaUrlChange]);

--- a/activity/src/components/RoleEditor.tsx
+++ b/activity/src/components/RoleEditor.tsx
@@ -101,18 +101,16 @@ export function RoleEditor({ player, onMediaUrlChange, hideSitOut }: RoleEditorP
   const handleCharacterSelect = useCallback(async (result: RaiderioCharacterResult) => {
     if (lookupLoading || !player.discordId) return;
 
+    // onChange already set nameRef to "Name-Realm"; cancel debounce to avoid racing the explicit save below.
+    if (saveTimerRef.current) {
+      clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = null;
+    }
+    const nameToSave = nameRef.current;
+
     const character = await lookup(result.name, result.realmSlug, result.region);
     if (character) {
       if (character.mediaUrl) onMediaUrlChange?.(character.mediaUrl);
-
-      // The onChange fired by CharacterSearchInput already put "Name-Realm" into
-      // the input and nameRef. Cancel the pending debounced save so we don't
-      // race with our explicit saveRoles below.
-      if (saveTimerRef.current) {
-        clearTimeout(saveTimerRef.current);
-        saveTimerRef.current = null;
-      }
-      const nameToSave = nameRef.current;
 
       // Save linkedCharacter + mediaUrl BEFORE saveRoles so the bot's
       // refreshPlayers cycle reads the mediaUrl from the preference doc.
@@ -138,10 +136,10 @@ export function RoleEditor({ player, onMediaUrlChange, hideSitOut }: RoleEditorP
         rolesRef.current = roleSet;
         await service.saveRoles(player.discordId, player.name, roles, nameToSave);
       } else {
-        await service.saveRoles(player.discordId, player.name, Array.from(selectedRoles), nameToSave);
+        await service.saveRoles(player.discordId, player.name, Array.from(rolesRef.current), nameToSave);
       }
     }
-  }, [lookupLoading, player, lookup, selectedRoles, service, onMediaUrlChange]);
+  }, [lookupLoading, player, lookup, service, onMediaUrlChange]);
 
   const isSittingOut = player.discordId ? sittingOut.includes(player.discordId) : false;
 


### PR DESCRIPTION
## Summary
- Clicking a suggestion in the in-game name autofill caused the textbox to briefly shorten to just the character name and then refill with the full "Name-Realm" text — visibly jarring.
- Root cause: `handleCharacterSelect` was calling `setInGameName(character.name)` after `lookup()` resolved, overwriting the `"Name-Realm"` value the earlier `onChange` had set. A debounced autosave scheduled from that same `onChange` then wrote `"Name-Realm"` to Firestore, and the snapshot sync restored it — producing the flash.
- There was also a race between the debounced autosave and the explicit `saveRoles(..., character.name)`, where the final stored value depended on which Firestore write landed last.

## Fix
- Remove the redundant `setInGameName(character.name)` / `nameRef.current = character.name` overwrite — the preceding `onChange` already set the correct `"Name-Realm"` value.
- Cancel the pending debounced autosave timer before the explicit save in `handleCharacterSelect` to eliminate the race.
- Pass `nameRef.current` (the same `"Name-Realm"` shown in the input) to `saveRoles` so the persisted value matches the displayed value.

## Test plan
- [ ] Type a partial name, click a suggestion from the dropdown — input should remain on `"Name-Realm"` with no flash to just the name.
- [ ] After clicking a suggestion, reload — persisted `inGameName` should be `"Name-Realm"`.
- [ ] First-time lookup (no roles yet) still auto-selects roles from character data.
- [ ] Subsequent lookup (roles already set) preserves the selected roles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)