### PR TITLE
fix: auto-load character image for existing inGameName

### DIFF
--- a/activity/src/components/RoleEditor.tsx
+++ b/activity/src/components/RoleEditor.tsx
@@ -13,7 +13,7 @@ import {
   UTILITY_BUTTONS,
   type RoleButtonDef,
 } from '../lib/roles';
-import type { RaiderioCharacterResult } from '../services/raiderioService';
+import { searchCharacters, type RaiderioCharacterResult } from '../services/raiderioService';
 import { reportError } from '../lib/sentry';
 
 interface RoleEditorProps {
@@ -35,6 +35,7 @@ export function RoleEditor({ player, onMediaUrlChange, hideSitOut }: RoleEditorP
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const rolesRef = useRef<Set<string>>(new Set());
   const nameRef = useRef<string>('');
+  const autoLookupAttemptedRef = useRef<string | null>(null);
 
   const playerId = player.discordId ?? null;
 
@@ -82,6 +83,60 @@ export function RoleEditor({ player, onMediaUrlChange, hideSitOut }: RoleEditorP
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
     };
   }, []);
+
+  // Auto-populate character image when a player already has an inGameName saved
+  // but no mediaUrl (e.g. name was entered in an older build or a previous session).
+  // Runs once per player identity; uses the initial snapshot to avoid firing while
+  // the user is typing. Failures are non-fatal.
+  useEffect(() => {
+    const discordId = player.discordId;
+    if (!discordId) return;
+    if (autoLookupAttemptedRef.current === discordId) return;
+    autoLookupAttemptedRef.current = discordId;
+
+    const name = player.inGameName?.trim();
+    if (!name || player.mediaUrl) return;
+
+    let cancelled = false;
+    const dashIdx = name.indexOf('-');
+    const namePart = dashIdx === -1 ? name : name.slice(0, dashIdx);
+    const realmPart = dashIdx === -1 ? '' : name.slice(dashIdx + 1);
+
+    (async () => {
+      try {
+        const matches = await searchCharacters(name);
+        if (cancelled || matches.length === 0) return;
+
+        const exact = matches.find(
+          (m) =>
+            m.name.toLowerCase() === namePart.toLowerCase() &&
+            (!realmPart ||
+              m.realm.toLowerCase() === realmPart.toLowerCase() ||
+              m.realmSlug.toLowerCase() === realmPart.toLowerCase()),
+        );
+        const match = exact ?? matches[0];
+
+        const character = await lookup(match.name, match.realmSlug, match.region);
+        if (cancelled || !character?.mediaUrl) return;
+
+        onMediaUrlChange?.(character.mediaUrl);
+        await service.saveLinkedCharacter(
+          discordId,
+          { name: match.name, realm: match.realmSlug, region: match.region },
+          character.mediaUrl,
+          character.class,
+        );
+      } catch (err) {
+        reportError(err, { tag: 'RoleEditor.autoLoadMedia' });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // Intentionally depend only on playerId — we take a snapshot of the player's
+    // inGameName/mediaUrl at mount and don't want to re-fire on typing changes.
+  }, [playerId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const toggleRole = useCallback((btnDef: RoleButtonDef, mutuallyExclusive: boolean) => {
     setSelectedRoles((prev) => {

--- a/activity/src/components/RoleEditor.tsx
+++ b/activity/src/components/RoleEditor.tsx
@@ -92,20 +92,20 @@ export function RoleEditor({ player, onMediaUrlChange, hideSitOut }: RoleEditorP
     const discordId = player.discordId;
     if (!discordId) return;
     if (autoLookupAttemptedRef.current === discordId) return;
-    autoLookupAttemptedRef.current = discordId;
 
     const name = player.inGameName?.trim();
     if (!name || player.mediaUrl) return;
+    autoLookupAttemptedRef.current = discordId;
 
-    let cancelled = false;
+    const controller = new AbortController();
     const dashIdx = name.indexOf('-');
     const namePart = dashIdx === -1 ? name : name.slice(0, dashIdx);
     const realmPart = dashIdx === -1 ? '' : name.slice(dashIdx + 1);
 
     (async () => {
       try {
-        const matches = await searchCharacters(name);
-        if (cancelled || matches.length === 0) return;
+        const matches = await searchCharacters(name, controller.signal);
+        if (controller.signal.aborted || matches.length === 0) return;
 
         const exact = matches.find(
           (m) =>
@@ -114,10 +114,13 @@ export function RoleEditor({ player, onMediaUrlChange, hideSitOut }: RoleEditorP
               m.realm.toLowerCase() === realmPart.toLowerCase() ||
               m.realmSlug.toLowerCase() === realmPart.toLowerCase()),
         );
+        // If the saved name includes a realm but no match confirms it, skip —
+        // falling back to matches[0] could silently load the wrong character.
+        if (!exact && realmPart) return;
         const match = exact ?? matches[0];
 
-        const character = await lookup(match.name, match.realmSlug, match.region);
-        if (cancelled || !character?.mediaUrl) return;
+        const character = await lookup(match.name, match.realmSlug, match.region, { silent: true });
+        if (controller.signal.aborted || !character?.mediaUrl) return;
 
         onMediaUrlChange?.(character.mediaUrl);
         await service.saveLinkedCharacter(
@@ -127,12 +130,13 @@ export function RoleEditor({ player, onMediaUrlChange, hideSitOut }: RoleEditorP
           character.class,
         );
       } catch (err) {
+        if (controller.signal.aborted) return;
         reportError(err, { tag: 'RoleEditor.autoLoadMedia' });
       }
     })();
 
     return () => {
-      cancelled = true;
+      controller.abort();
     };
     // Intentionally depend only on playerId — we take a snapshot of the player's
     // inGameName/mediaUrl at mount and don't want to re-fire on typing changes.

--- a/activity/src/hooks/useCharacterLookup.ts
+++ b/activity/src/hooks/useCharacterLookup.ts
@@ -25,8 +25,14 @@ export function useCharacterLookup() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  async function lookup(name: string, realm: string, region: string): Promise<CharacterData | null> {
-    setLoading(true);
+  async function lookup(
+    name: string,
+    realm: string,
+    region: string,
+    options?: { silent?: boolean },
+  ): Promise<CharacterData | null> {
+    const silent = options?.silent === true;
+    if (!silent) setLoading(true);
     setError(null);
 
     const isDemoMode = useAppStore.getState().isDemoMode;
@@ -61,7 +67,7 @@ export function useCharacterLookup() {
       setError(message);
       return null;
     } finally {
-      setLoading(false);
+      if (!silent) setLoading(false);
     }
   }
 


### PR DESCRIPTION
## Summary
- Players with a saved `inGameName` but no `mediaUrl` (e.g. from an older build or a previous session) had to re-enter their name and pick from the dropdown before the character portrait would render.
- `RoleEditor` now runs a one-shot auto-lookup on mount: it calls `searchCharacters(inGameName)` to resolve region + realm slug, then routes through the existing `lookup()` + `saveLinkedCharacter()` path so the image appears and `mediaUrl` is persisted to Firestore.
- Effect depends only on `playerId` and uses a `useRef` guard so typing in the name field can't retrigger the lookup; failures are reported to Sentry and are non-fatal.

## Test plan
- [x] `./scripts/verify-activity.sh` (typecheck + build + 156 Playwright tests pass)
- [ ] Manually verify: open `/activity` with a player whose `inGameName` is set but whose `mediaUrl` is missing — the spinner should appear briefly and the portrait should populate without any user interaction
- [ ] Manually verify: opening `/activity` as a brand-new player (no `inGameName`) does not trigger a stray search request

🤖 Generated with [Claude Code](https://claude.com/claude-code)