### PR TITLE
fix: preserve user-typed text in character search input

### DIFF
--- a/activity/src/components/RoleEditor.tsx
+++ b/activity/src/components/RoleEditor.tsx
@@ -39,14 +39,23 @@ export function RoleEditor({ player, onMediaUrlChange, hideSitOut }: RoleEditorP
 
   const playerId = player.discordId ?? null;
 
-  // Sync roles and name when player data changes from Firestore
+  // Sync roles when player data changes from Firestore (chips need to reflect
+  // external updates).
   useEffect(() => {
     const roles = new Set(playerRolesToStringArray(player));
     setSelectedRoles(roles);
     rolesRef.current = roles;
+  }, [player]);
+
+  // Seed the in-game name ONLY on player identity change. After mount, the
+  // textbox is user-controlled — we never let a Firestore roundtrip overwrite
+  // what the user has typed (e.g. replacing "Name-Realm" with a partial or
+  // name-only value from the bot's cache). Users always enter the full
+  // `Name-Realm` form; clicking a suggestion also produces `Name-Realm`.
+  useEffect(() => {
     setInGameName(player.inGameName ?? '');
     nameRef.current = player.inGameName ?? '';
-  }, [playerId, player]);
+  }, [playerId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Auto-save when roles or name change
   const autoSave = useCallback((roles: Set<string>, name: string) => {

--- a/activity/src/components/RoleEditor.tsx
+++ b/activity/src/components/RoleEditor.tsx
@@ -40,11 +40,16 @@ export function RoleEditor({ player, onMediaUrlChange, hideSitOut }: RoleEditorP
   const playerId = player.discordId ?? null;
 
   // Sync roles when player data changes from Firestore (chips need to reflect
-  // external updates).
+  // external updates). Bail when the role set hasn't changed — `autoSave`
+  // optimistically updates the store on every keystroke, so this effect fires
+  // frequently during typing.
   useEffect(() => {
-    const roles = new Set(playerRolesToStringArray(player));
-    setSelectedRoles(roles);
-    rolesRef.current = roles;
+    const next = new Set(playerRolesToStringArray(player));
+    setSelectedRoles((prev) => {
+      if (prev.size === next.size && [...next].every((r) => prev.has(r))) return prev;
+      return next;
+    });
+    rolesRef.current = next;
   }, [player]);
 
   // Seed the in-game name ONLY on player identity change. After mount, the


### PR DESCRIPTION
## Summary
- The sync effect in `RoleEditor` ran on every `player` prop change (new reference on every Firestore update) and always rewrote the local `inGameName` state from `player.inGameName`. When the bot's cache roundtripped back a partial or name-only value, this would wipe what the user had typed, producing the "text disappears and reappears" effect in the character search textbox.
- Split the sync: roles continue to reflect external updates on every player change, but the textbox is now only seeded on **player identity change**. After mount, the input is user-controlled — no Firestore roundtrip can clobber it.
- Users always enter `Name-Realm` form and the suggestion-click path already produces `Name-Realm`, so bare name-only values from external sources should never be forced into the textbox — which is exactly the behavior this change preserves.

## Test plan
- [x] `./scripts/verify-activity.sh` (typecheck + build + 156 Playwright tests pass)
- [ ] Manually verify: load `/activity` with a player whose saved `inGameName` is `Name-Realm`. The textbox shows the full value immediately and never flickers/clears during role edits or auto-save roundtrips.
- [ ] Manually verify: typing in the textbox is never interrupted by external syncs.
- [ ] Manually verify: clicking a suggestion sets `Name-Realm` and it stays put.

🤖 Generated with [Claude Code](https://claude.com/claude-code)