### PR TITLE
perf: tighten effect deps to stop firing on every Firestore snapshot

### DIFF
--- a/activity/src/hooks/useIdentityResolver.ts
+++ b/activity/src/hooks/useIdentityResolver.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useIdentity } from './useIdentity';
 import { WoWPlayer } from '../types';
 
@@ -9,11 +9,27 @@ import { WoWPlayer } from '../types';
 export function useIdentityResolver(players: WoWPlayer[]) {
   const identity = useIdentity();
 
+  // Firestore snapshots produce a new `players` array ref on every update
+  // (including keystrokes). Reduce to a membership signature so we only
+  // re-resolve when the set of discordIds actually changes.
+  const membershipKey = useMemo(
+    () =>
+      players
+        .map((p) => p.discordId ?? `name:${p.name}`)
+        .sort()
+        .join(','),
+    [players],
+  );
+
+  const playersRef = useRef(players);
+  playersRef.current = players;
+
+  const { resolveIdentity } = identity;
   useEffect(() => {
-    if (players.length > 0) {
-      identity.resolveIdentity(players).catch(console.error);
+    if (playersRef.current.length > 0) {
+      resolveIdentity(playersRef.current).catch(console.error);
     }
-  }, [players, identity.resolveIdentity]);
+  }, [membershipKey, resolveIdentity]);
 
   return identity;
 }

--- a/activity/src/hooks/useIdentityResolver.ts
+++ b/activity/src/hooks/useIdentityResolver.ts
@@ -15,7 +15,7 @@ export function useIdentityResolver(players: WoWPlayer[]) {
   const membershipKey = useMemo(
     () =>
       players
-        .map((p) => p.discordId ?? `name:${p.name}`)
+        .map((p) => p.discordId ?? `\0${p.name}`)
         .sort()
         .join(','),
     [players],

--- a/activity/src/types.ts
+++ b/activity/src/types.ts
@@ -40,6 +40,7 @@ export interface ChannelData {
   refreshPlayers?: boolean;
   claimedPlayers?: string[];
   sittingOut?: string[];
+  staticWheel?: boolean;
   isDebug: boolean;
   createdAt: unknown;
   lastActive: unknown;

--- a/activity/src/views/ChannelsView.tsx
+++ b/activity/src/views/ChannelsView.tsx
@@ -24,12 +24,14 @@ export function ChannelsView({ onNavigate }: ChannelsViewProps) {
   const channels = guildData?.voiceChannels || [];
 
   const hasAutoRefreshed = useRef(false);
+  const hasGuildData = guildData != null;
+  const channelsCount = channels.length;
   useEffect(() => {
-    if (!hasAutoRefreshed.current && guildData && channels.length === 0 && currentGuildId) {
+    if (!hasAutoRefreshed.current && hasGuildData && channelsCount === 0 && currentGuildId) {
       hasAutoRefreshed.current = true;
       service.refreshChannels(currentGuildId).catch((err) => reportError(err, { tag: 'ChannelsView.autoRefresh' }));
     }
-  }, [guildData, channels.length, currentGuildId, service]);
+  }, [hasGuildData, channelsCount, currentGuildId, service]);
 
   const handleRefresh = useCallback(async () => {
     if (!currentGuildId) return;

--- a/activity/src/views/WheelsView.tsx
+++ b/activity/src/views/WheelsView.tsx
@@ -88,13 +88,13 @@ export function WheelsView({ onNavigate }: WheelsViewProps) {
 
   const channelStatus = channelData?.status;
   const groupsCount = channelData?.groups?.length ?? 0;
-  const isStaticWheel = (channelData as unknown as Record<string, unknown> | undefined)?.staticWheel === true;
+  const isStaticWheel = channelData?.staticWheel === true;
 
   useEffect(() => {
     const data = useAppStore.getState().channelData;
     if (!data || data.status !== 'spinning') return;
 
-    if ((data as unknown as Record<string, unknown>).staticWheel) {
+    if (data.staticWheel) {
       const p = initPools(data.players);
       useAppStore.getState().setPools(p.tanks, p.healers, p.dps);
       setWheelStatus('Static preview');

--- a/activity/src/views/WheelsView.tsx
+++ b/activity/src/views/WheelsView.tsx
@@ -86,26 +86,31 @@ export function WheelsView({ onNavigate }: WheelsViewProps) {
 
   const pools = markedPools;
 
-  useEffect(() => {
-    if (!channelData || channelData.status !== 'spinning') return;
+  const channelStatus = channelData?.status;
+  const groupsCount = channelData?.groups?.length ?? 0;
+  const isStaticWheel = (channelData as unknown as Record<string, unknown> | undefined)?.staticWheel === true;
 
-    if ((channelData as unknown as Record<string, unknown>).staticWheel) {
-      const p = initPools(channelData.players);
+  useEffect(() => {
+    const data = useAppStore.getState().channelData;
+    if (!data || data.status !== 'spinning') return;
+
+    if ((data as unknown as Record<string, unknown>).staticWheel) {
+      const p = initPools(data.players);
       useAppStore.getState().setPools(p.tanks, p.healers, p.dps);
       setWheelStatus('Static preview');
       setShowSpinBtn(false);
       return;
     }
 
-    if (channelData.groups && channelData.groups.length > 0 && !spinSequenceStarted) {
-      const full = channelData.groups.filter(isCompleteGroup);
-      const remainder = channelData.groups.filter((g) => !isCompleteGroup(g));
+    if (data.groups && data.groups.length > 0 && !spinSequenceStarted) {
+      const full = data.groups.filter(isCompleteGroup);
+      const remainder = data.groups.filter((g) => !isCompleteGroup(g));
       useAppStore.getState().setSpinState(full, remainder);
       useAppStore.getState().setSpinSequenceStarted(true);
       useAppStore.getState().setCurrentGroupIndex(0);
       useAppStore.getState().clearGroupCards();
 
-      const p = initPools(channelData.players);
+      const p = initPools(data.players);
       useAppStore.getState().setPools(p.tanks, p.healers, p.dps);
 
       gridRef.current?.grid?.resetCarouselDots();
@@ -114,7 +119,7 @@ export function WheelsView({ onNavigate }: WheelsViewProps) {
       setShowSpinBtn(true);
       setWheelStatus('Ready to spin!');
     }
-  }, [channelData, spinSequenceStarted]);
+  }, [channelStatus, groupsCount, isStaticWheel, spinSequenceStarted]);
 
   useEffect(() => {
     if (!channelData || !spinSequenceStarted) return;


### PR DESCRIPTION
## Summary

Three `useEffect` hooks were keyed on blob objects (`players`, `channelData`, `guildData`) that Firestore's `onSnapshot` re-creates wholesale on every update — including every keystroke that triggers an optimistic store write. Behavior is unchanged; they just stop churning.

- **`useIdentityResolver`** — was re-iterating players on every snapshot. Now keyed on a membership signature (sorted discordIds joined) so it only re-resolves when the set actually changes. Uses a ref to pass the current array to `resolveIdentity` without making it a dep.
- **`WheelsView` ready-to-spin effect** — was keyed on `channelData` blob. Now keyed on `channelStatus`, `groupsCount`, `isStaticWheel`, `spinSequenceStarted`. Reads the fresh `channelData` inside via `useAppStore.getState()`.
- **`ChannelsView` auto-refresh effect** — was keyed on `guildData` blob. Now keyed on `hasGuildData` + `channelsCount` + `currentGuildId`.

## Test plan

- [x] Typecheck: `npm run typecheck` clean
- [x] Lint: only pre-existing warning (unrelated `WheelsView` effect on line 139) remains
- [x] Build: `vite build` succeeds
- [x] Playwright (Docker): 156/156 pass, no snapshot changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)