### PR TITLE
fix: shift affix refresh to Tuesday 4pm PT

### DIFF
--- a/packages/functions/src/fetchWeeklyAffixes.ts
+++ b/packages/functions/src/fetchWeeklyAffixes.ts
@@ -69,10 +69,10 @@ export async function fetchAndWriteAffixes(): Promise<Omit<AffixDocument, 'lastU
 // Scheduled: fires weekly on Tuesdays
 export const fetchWeeklyAffixes = onSchedule(
   {
-    // Fires 2 hours after NA weekly reset (15:00 UTC). EU resets Wednesday 04:00 UTC,
-    // but affixes are the same globally so NA timing is fine for all regions.
-    schedule: 'every tuesday 17:00',
-    timeZone: 'UTC',
+    // Tuesday 16:00 Pacific (~8h after NA weekly reset). Earlier runs caught
+    // Raider.IO before it had rolled its affixes endpoint to the new week.
+    schedule: 'every tuesday 16:00',
+    timeZone: 'America/Los_Angeles',
   },
   async () => {
     await fetchAndWriteAffixes();


### PR DESCRIPTION
## Summary
- Raider.IO's `/mythic-plus/affixes` endpoint didn't roll over to the new week's Bargain by the time our scheduler ran (Tuesday 17:00 UTC, 2h after NA reset), so Firestore got last week's Pulsar instead of this week's Ascendant.
- Shift the weekly schedule to `every tuesday 16:00` in `America/Los_Angeles` (~8h after reset) to give upstream time to settle.
- Firestore `config/affixes` was manually refreshed to correct Ascendant after deploying this fix locally.

## Test plan
- [ ] After merge + deploy, confirm `firebase-schedule-fetchWeeklyAffixes-us-central1` in Cloud Scheduler shows the new schedule/timezone
- [ ] Verify next Tuesday's run writes the correct week's Bargain

🤖 Generated with [Claude Code](https://claude.com/claude-code)