### PR TITLE
fix: route raider.io through Discord activity proxy

### DIFF
--- a/activity/src/discordSdk.ts
+++ b/activity/src/discordSdk.ts
@@ -39,6 +39,8 @@ if (_isEmbedded) {
     { prefix: '/authtoken', target: 'securetoken.googleapis.com' },
     // Battle.net character renders (profile pictures)
     { prefix: IMAGE_PROXY_PREFIX, target: IMAGE_PROXY_TARGET },
+    // Raider.io character search + profile lookup
+    { prefix: '/raiderio', target: 'raider.io' },
   ];
 
   // Cloud Functions callable endpoint must also be proxied in embedded mode.


### PR DESCRIPTION
## Summary
- Add `/raiderio` → `raider.io` to `patchUrlMappings` in `activity/src/discordSdk.ts`
- Fixes character-name autocomplete and auto-load portrait lookup for users launching the activity inside Discord

## Why
Users launching via Discord saw no autocomplete results and no auto-loaded character portrait. Inside Discord's activity iframe, `patchUrlMappings` rewrites outbound `fetch`/XHR by hostname, and anything not declared is blocked by CSP. The existing mappings cover Firestore, Firebase Auth, Cloud Functions, and Battle.net renders — but not raider.io, which both `searchCharacters` and `lookupCharacterProfile` hit directly.

Browser-direct dev (Vite) wasn't affected since `isEmbedded` is false there and `patchUrlMappings` is a no-op.

The matching `/raiderio` → `raider.io` URL Mapping has already been added in the Discord Developer Portal (required separately — the SDK call alone isn't enough to get past CSP).

## Test plan
- [ ] Typecheck: `cd activity && npm run typecheck` (✓ locally)
- [ ] After deploy, launch activity inside Discord and type 3+ chars in a player's name field → autocomplete dropdown populates
- [ ] Player with an existing `inGameName` but no `mediaUrl` → portrait auto-loads on mount
- [ ] Browser-direct dev still works (no regression for non-embedded mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)