### PR TITLE
chore: address Gemini review feedback on wheel refactor

### DIFF
--- a/activity/.storybook/main.ts
+++ b/activity/.storybook/main.ts
@@ -24,6 +24,6 @@ const config: StorybookConfig = {
 };
 export default config;
 
-function getAbsolutePath(value: string): any {
+function getAbsolutePath(value: string): string {
   return dirname(fileURLToPath(import.meta.resolve(`${value}/package.json`)));
 }

--- a/activity/src/components/Wheel.stories.tsx
+++ b/activity/src/components/Wheel.stories.tsx
@@ -238,11 +238,11 @@ export const InteractiveSpin: Story = {
 
 function InteractiveHarness({ args }: { args: WheelProps }) {
   const ref = useRef<WheelHandle>(null);
-  useEffect(() => {
-    ref.current?.init(args.initialEntries ?? []);
-  }, [args.initialEntries]);
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      {/* Initial entries + rotation are passed declaratively; no imperative
+          init() on mount — that would reset the rotation and race with the
+          first render. */}
       <Wheel ref={ref} {...args} />
       <div style={{ display: 'flex', gap: 8, justifyContent: 'center' }}>
         {(args.initialEntries ?? []).slice(0, 3).map((e) => (


### PR DESCRIPTION
Follow-up to #423 addressing the two medium-priority comments from Gemini's review (which posted after the merge).

## Changes

- **`activity/.storybook/main.ts`** — `getAbsolutePath` return type `any` → `string`. The helper was auto-generated by the Storybook 10.3.5 migration; tightening the signature restores type safety.
- **`activity/src/components/Wheel.stories.tsx`** — dropped the `useEffect(() => ref.current?.init(...))` call in `InteractiveHarness`. `Wheel` already reads `initialEntries` + `initialRotation` declaratively from props, and the effect was racing with the first render and stomping the random initial rotation with a fresh one.

## Test plan

- [x] `npm run typecheck` passes
- [x] Local Storybook Interactive story still spins correctly
- [ ] Reviewer: open the Interactive story and verify the spin button still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)