### PR TITLE
feat(activity): stagger wheel landings for distinct portrait reveals

### DIFF
--- a/activity/src/lib/timing.ts
+++ b/activity/src/lib/timing.ts
@@ -1,7 +1,10 @@
 // ── Configurable Timing Constants ────────────────────────────
 export const CAROUSEL_SPIN_DURATION = 2000;   // ms per wheel in carousel mode
 export const CAROUSEL_ADVANCE_DELAY = 400;    // ms pause after each landing
-export const GRID_SPIN_DURATION = 4000;       // ms per wheel in grid mode
+// Per-wheel spin durations in grid mode, ordered tank → healer → dps1/2/3.
+// Each wheel lands ~400ms after the previous so portrait reveals are
+// individually visible instead of clumping into a single pop.
+export const GRID_SPIN_DURATIONS = [2500, 2900, 3300, 3700, 4100];
 
 // Portrait reveal timing — runs in parallel with audio.land() so the portrait
 // finishes expanding as the "pop" sound plays. Matches the land() sound's ~200ms

--- a/activity/src/views/WheelsView.tsx
+++ b/activity/src/views/WheelsView.tsx
@@ -151,13 +151,13 @@ export function WheelsView({ onNavigate }: WheelsViewProps) {
     grid.clearAllResults();
     grid.initWheels(markedPools);
 
+    const wheels = grid.orderedWheels();
+    const winners = [group.tank, group.healer, ...group.dps];
     const spinPromises: Promise<string>[] = [];
-    if (group.tank) spinPromises.push(grid.tank.spinTo(group.tank.name, GRID_SPIN_DURATIONS[0]));
-    if (group.healer) spinPromises.push(grid.healer.spinTo(group.healer.name, GRID_SPIN_DURATIONS[1]));
-
-    const dpsWheels = [grid.dps1, grid.dps2, grid.dps3];
-    group.dps.forEach((dpsPlayer, i) => {
-      if (dpsWheels[i]) spinPromises.push(dpsWheels[i].spinTo(dpsPlayer.name, GRID_SPIN_DURATIONS[i + 2]));
+    winners.forEach((winner, i) => {
+      if (winner && wheels[i]) {
+        spinPromises.push(wheels[i].spinTo(winner.name, GRID_SPIN_DURATIONS[i]));
+      }
     });
 
     await Promise.all(spinPromises);

--- a/activity/src/views/WheelsView.tsx
+++ b/activity/src/views/WheelsView.tsx
@@ -17,7 +17,7 @@ import { audio } from '../lib/audio';
 import { reportError } from '../lib/sentry';
 import {
   delay,
-  CAROUSEL_SPIN_DURATION, CAROUSEL_ADVANCE_DELAY, GRID_SPIN_DURATION,
+  CAROUSEL_SPIN_DURATION, CAROUSEL_ADVANCE_DELAY, GRID_SPIN_DURATIONS,
   SPOTLIGHT_HOLD_DURATION, SPOTLIGHT_ENTER_DURATION, SPOTLIGHT_EXIT_DURATION,
   WHEELS_FADE_DURATION, POST_LAND_PAUSE,
   PROGRESS_FADE_DURATION,
@@ -152,13 +152,12 @@ export function WheelsView({ onNavigate }: WheelsViewProps) {
     grid.initWheels(markedPools);
 
     const spinPromises: Promise<string>[] = [];
-    if (group.tank) spinPromises.push(grid.tank.spinTo(group.tank.name, GRID_SPIN_DURATION));
-    if (group.healer) spinPromises.push(grid.healer.spinTo(group.healer.name, GRID_SPIN_DURATION));
+    if (group.tank) spinPromises.push(grid.tank.spinTo(group.tank.name, GRID_SPIN_DURATIONS[0]));
+    if (group.healer) spinPromises.push(grid.healer.spinTo(group.healer.name, GRID_SPIN_DURATIONS[1]));
 
     const dpsWheels = [grid.dps1, grid.dps2, grid.dps3];
-    const dpsDurations = [GRID_SPIN_DURATION, GRID_SPIN_DURATION + 300, GRID_SPIN_DURATION + 600];
     group.dps.forEach((dpsPlayer, i) => {
-      if (dpsWheels[i]) spinPromises.push(dpsWheels[i].spinTo(dpsPlayer.name, dpsDurations[i]));
+      if (dpsWheels[i]) spinPromises.push(dpsWheels[i].spinTo(dpsPlayer.name, GRID_SPIN_DURATIONS[i + 2]));
     });
 
     await Promise.all(spinPromises);


### PR DESCRIPTION
## Summary

- In grid mode, tank/healer/dps1 all spun for 4000ms, so three portraits popped in simultaneously and you couldn't see who was actually picked.
- Replaces the single `GRID_SPIN_DURATION` constant with a per-wheel `GRID_SPIN_DURATIONS` array `[2500, 2900, 3300, 3700, 4100]` — 400ms between each landing, starting earlier overall.
- Each wheel now lands distinctly enough for the 200ms portrait expand to register before the next pop.

## Test plan

- [ ] Run `/activity`, spin a group, and confirm each of the 5 portraits pops in sequence with visible spacing
- [ ] Confirm tank lands first, dps3 last, and total spin time feels snappier than before
- [ ] Verify Storybook wheel stories still render (no broken imports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)