### PR TITLE
perf: preload spotlight portraits while in lobby

### DIFF
--- a/activity/src/App.tsx
+++ b/activity/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useCallback, useRef } from 'react';
 import { useAppStore } from './store/store';
 import { useGuildSubscription, useChannelSubscription } from './hooks/useSession';
 import { useRecentGuilds } from './hooks/useRecentGuilds';
+import { usePreloadPortraits } from './hooks/usePreloadPortraits';
 import { statusToView, routeToView, viewToRoute } from './lib/routing';
 import type { ViewName } from './store/types';
 import { isPlayerReady } from './lib/roles';
@@ -52,6 +53,10 @@ export function App() {
   // Subscribe to guild and channel Firestore docs
   useGuildSubscription();
   useChannelSubscription();
+
+  // Warm browser cache with spotlight portraits while user is in lobby/setup,
+  // so the wheel landing and results views render instantly.
+  usePreloadPortraits(channelData?.players);
 
   // Save recent guilds when guild data arrives
   const savedGuildRef = useRef<string | null>(null);

--- a/activity/src/hooks/usePreloadPortraits.ts
+++ b/activity/src/hooks/usePreloadPortraits.ts
@@ -1,0 +1,24 @@
+import { useEffect, useRef } from 'react';
+import type { WoWPlayer } from '../types';
+import { toMainBodyUrl } from '../lib/characterMedia';
+import { remapImageUrl } from '../discordSdk';
+
+/**
+ * Kick off background fetches for full-body spotlight portraits as soon as
+ * players are known. Browsers cache by URL, so the eventual <img> renders in
+ * SpotlightPortrait hit cache instead of waiting on Blizzard's CDN.
+ */
+export function usePreloadPortraits(players: WoWPlayer[] | undefined | null) {
+  const preloaded = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!players) return;
+    for (const player of players) {
+      const url = remapImageUrl(toMainBodyUrl(player.mediaUrl));
+      if (!url || preloaded.current.has(url)) continue;
+      preloaded.current.add(url);
+      const img = new Image();
+      img.src = url;
+    }
+  }, [players]);
+}

--- a/activity/src/hooks/usePreloadPortraits.ts
+++ b/activity/src/hooks/usePreloadPortraits.ts
@@ -14,9 +14,11 @@ export function usePreloadPortraits(players: WoWPlayer[] | undefined | null) {
   useEffect(() => {
     if (!players) return;
     for (const player of players) {
-      const url = remapImageUrl(toMainBodyUrl(player.mediaUrl));
-      if (!url || preloaded.current.has(url)) continue;
-      preloaded.current.add(url);
+      const mediaUrl = player.mediaUrl;
+      if (!mediaUrl || preloaded.current.has(mediaUrl)) continue;
+      preloaded.current.add(mediaUrl);
+      const url = remapImageUrl(toMainBodyUrl(mediaUrl));
+      if (!url) continue;
       const img = new Image();
       img.src = url;
     }


### PR DESCRIPTION
## Summary
- Adds a `usePreloadPortraits` hook that kicks off `Image()` fetches for each player's full-body character portrait as soon as they appear in Firestore.
- Wires it into `App.tsx` next to the existing guild/channel subscriptions, so portraits warm the browser cache during lobby/setup before the wheel reveal or results view ever renders one.

The full-body PNGs from Blizzard are ~1–2 MB each (1400×2800 transparent). They're displayed at 88–176 px wide, so the bytes are oversized — but resizing requires either a third-party proxy (wsrv.nl) with a new Discord URL mapping or a Cloud Function with caching. This change is the zero-infra first step: same total bytes, but the wait moves out of the user's critical path.

## Test plan
- [ ] Open `/activity` in a voice channel with members; observe Network tab — `*-main-raw.png` requests fire while still in lobby/setup.
- [ ] Click Spin and verify spotlight portraits render without visible loading delay.
- [ ] Reload mid-spin and confirm portraits still appear (preload runs from `App.tsx`, not just `LobbyView`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)