### PR TITLE
feat(activity): tighten wheel spin stagger to 200ms

### DIFF
--- a/activity/src/lib/timing.ts
+++ b/activity/src/lib/timing.ts
@@ -2,9 +2,9 @@
 export const CAROUSEL_SPIN_DURATION = 2000;   // ms per wheel in carousel mode
 export const CAROUSEL_ADVANCE_DELAY = 400;    // ms pause after each landing
 // Per-wheel spin durations in grid mode, ordered tank → healer → dps1/2/3.
-// Each wheel lands ~400ms after the previous so portrait reveals are
+// Each wheel lands 200ms after the previous so portrait reveals are
 // individually visible instead of clumping into a single pop.
-export const GRID_SPIN_DURATIONS = [2500, 2900, 3300, 3700, 4100];
+export const GRID_SPIN_DURATIONS = [3000, 3200, 3400, 3600, 3800];
 
 // Portrait reveal timing — runs in parallel with audio.land() so the portrait
 // finishes expanding as the "pop" sound plays. Matches the land() sound's ~200ms


### PR DESCRIPTION
## Summary
- Reduce per-wheel landing stagger from 400ms to 200ms (`GRID_SPIN_DURATIONS`)
- Shift first wheel landing 500ms later (2500ms → 3000ms) for a brief suspense beat before reveals start
- Net: shorter total reveal sequence (1600ms span → 800ms span) with a slower opener

## Test plan
- [ ] Run `/activity` flow and watch grid-mode spin: tank lands ~3s in, each subsequent wheel lands ~200ms apart
- [ ] Confirm portrait reveal animations remain individually visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)