### PR TITLE
feat(activity): hover spotlight portraits to see M+ scores

### DIFF
--- a/activity/src/components/SpotlightPortrait.tsx
+++ b/activity/src/components/SpotlightPortrait.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import type { CharacterClass } from '@mythicplus/shared';
+import type { CharacterDungeonScores } from '../services/raiderioMythicPlus';
 import { remapImageUrl } from '../discordSdk';
 import { toMainBodyUrl } from '../lib/characterMedia';
 import { getClassColor } from '../lib/classColors';
@@ -8,6 +9,8 @@ interface SpotlightPortraitProps {
   name: string;
   characterClass: CharacterClass | null | undefined;
   mediaUrl: string | null | undefined;
+  /** When provided, hovering/focusing the portrait shows a Raider.io score tooltip. */
+  scores?: CharacterDungeonScores | null;
 }
 
 const DEFAULT_COLOR = '#808080';
@@ -24,18 +27,22 @@ function FallbackAvatar({ color }: { color: string }) {
   );
 }
 
-export function SpotlightPortrait({ name, characterClass, mediaUrl }: SpotlightPortraitProps) {
+export function SpotlightPortrait({ name, characterClass, mediaUrl, scores }: SpotlightPortraitProps) {
   const fullBodyUrl = toMainBodyUrl(mediaUrl);
   const proxiedUrl = remapImageUrl(fullBodyUrl);
   const color = getClassColor(characterClass) ?? DEFAULT_COLOR;
   const [failed, setFailed] = useState(false);
   const showImage = proxiedUrl && !failed;
+  const tooltipId = useId();
+  const hasTooltip = Boolean(scores);
 
   return (
     <div
-      className="spotlight-portrait"
+      className={`spotlight-portrait${hasTooltip ? ' spotlight-portrait--has-tooltip' : ''}`}
       style={{ '--ch-color': color } as React.CSSProperties}
-      title={name}
+      title={hasTooltip ? undefined : name}
+      tabIndex={hasTooltip ? 0 : undefined}
+      aria-describedby={hasTooltip ? tooltipId : undefined}
     >
       <div className="spotlight-portrait__stage">
         {showImage ? (
@@ -50,6 +57,60 @@ export function SpotlightPortrait({ name, characterClass, mediaUrl }: SpotlightP
         )}
         <div className="spotlight-portrait__name">{name}</div>
       </div>
+      {hasTooltip && scores && (
+        <ScoreTooltip id={tooltipId} name={name} scores={scores} />
+      )}
+    </div>
+  );
+}
+
+interface ScoreTooltipProps {
+  id: string;
+  name: string;
+  scores: CharacterDungeonScores;
+}
+
+function ScoreTooltip({ id, name, scores }: ScoreTooltipProps) {
+  // Per-dungeon entries sorted by best score, descending — highest first
+  // matches what the player would expect to see on their Raider.io page.
+  const dungeons = Object.values(scores.byDungeon)
+    .filter(d => d.score > 0)
+    .sort((a, b) => b.score - a.score);
+
+  return (
+    <div role="tooltip" id={id} className="spotlight-portrait__tooltip">
+      <div className="spotlight-portrait__tooltip-header">
+        <span className="spotlight-portrait__tooltip-name">{name}</span>
+        <span className="spotlight-portrait__tooltip-overall">
+          {scores.overallScore !== null ? (
+            <>
+              <strong style={{ color: scores.scoreColor ?? 'inherit' }}>
+                {Math.round(scores.overallScore)}
+              </strong>
+              <span className="spotlight-portrait__tooltip-overall-label"> RIO</span>
+            </>
+          ) : (
+            <span className="spotlight-portrait__tooltip-overall-label">No score yet</span>
+          )}
+        </span>
+      </div>
+      {dungeons.length > 0 ? (
+        <ul className="spotlight-portrait__tooltip-list">
+          {dungeons.map((d) => (
+            <li key={d.challengeModeId} className="spotlight-portrait__tooltip-row">
+              <span className="spotlight-portrait__tooltip-dungeon" title={d.name}>
+                {d.name || d.shortName}
+              </span>
+              <span className="spotlight-portrait__tooltip-key">+{d.level}</span>
+              <span className="spotlight-portrait__tooltip-score">
+                {Math.round(d.score)}
+              </span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="spotlight-portrait__tooltip-empty">No timed runs yet this season.</p>
+      )}
     </div>
   );
 }

--- a/activity/src/components/SpotlightPortraits.tsx
+++ b/activity/src/components/SpotlightPortraits.tsx
@@ -1,23 +1,36 @@
 import { WoWPlayer } from '../types';
+import type { CharacterDungeonScores } from '../services/raiderioMythicPlus';
 import { SpotlightPortrait } from './SpotlightPortrait';
 
 interface SpotlightPortraitsProps {
   players: WoWPlayer[];
+  /**
+   * Optional per-player Raider.io M+ score data. When supplied, each portrait
+   * shows a hover/focus tooltip with overall + per-dungeon scores. Used by
+   * the Results view; the wheel-reveal SpotlightCard leaves it undefined.
+   */
+  scoresByDiscordId?: ReadonlyMap<string, CharacterDungeonScores | null>;
 }
 
-export function SpotlightPortraits({ players }: SpotlightPortraitsProps) {
+export function SpotlightPortraits({ players, scoresByDiscordId }: SpotlightPortraitsProps) {
   if (players.length === 0) return null;
 
   return (
     <div className="spotlight-portraits" data-testid="spotlight-portraits">
-      {players.map((player, index) => (
-        <SpotlightPortrait
-          key={player.discordId || player.name || index}
-          name={player.name}
-          characterClass={player.characterClass}
-          mediaUrl={player.mediaUrl}
-        />
-      ))}
+      {players.map((player, index) => {
+        const scores = player.discordId
+          ? scoresByDiscordId?.get(player.discordId) ?? null
+          : null;
+        return (
+          <SpotlightPortrait
+            key={player.discordId || player.name || index}
+            name={player.name}
+            characterClass={player.characterClass}
+            mediaUrl={player.mediaUrl}
+            scores={scores}
+          />
+        );
+      })}
     </div>
   );
 }

--- a/activity/src/hooks/useDungeonSuggestions.ts
+++ b/activity/src/hooks/useDungeonSuggestions.ts
@@ -9,11 +9,11 @@ import type { WoWPlayer } from '../types';
 const DEFAULT_REGION = 'us';
 
 interface FetchState {
-  // The "fetch-side" status. The visible status that the consumer sees is
-  // derived below — it can promote to 'error' or stay 'empty' depending on
-  // whether the ranking is computable.
   phase: 'idle' | 'loading' | 'fetched' | 'no-targets';
+  /** One entry per *unique* character (by region/realm/name), in target order. */
   characters: (CharacterDungeonScores | null)[];
+  /** Maps discordId → index into `characters` for the player's character. */
+  characterIndexByDiscordId: Record<string, number>;
   serviceErrors: number;
   lookupTargetCount: number;
 }
@@ -21,15 +21,35 @@ interface FetchState {
 const IDLE_FETCH_STATE: FetchState = {
   phase: 'idle',
   characters: [],
+  characterIndexByDiscordId: {},
   serviceErrors: 0,
   lookupTargetCount: 0,
 };
 
-interface LookupTarget {
+interface PlayerTarget {
+  discordId: string;
   key: string;
   name: string;
   realm: string;
   region: string;
+}
+
+interface UniqueLookup {
+  key: string;
+  name: string;
+  realm: string;
+  region: string;
+}
+
+export interface UseDungeonSuggestionsResult {
+  /** The aggregated ranking + status that drives the panel UI. */
+  state: DungeonSuggestionsState;
+  /**
+   * Per-player M+ score data keyed by Discord ID. Players without a parseable
+   * `inGameName` are absent from the map; players whose lookup is in flight
+   * are absent until the fetch settles. Lookup failures map to `null`.
+   */
+  scoresByDiscordId: ReadonlyMap<string, CharacterDungeonScores | null>;
 }
 
 function realmToSlug(realm: string): string {
@@ -52,61 +72,84 @@ function parseInGameName(input: string | undefined | null): { name: string; real
   return { name, realmSlug: realmToSlug(realm) };
 }
 
-function buildLookupTargets(players: readonly WoWPlayer[]): LookupTarget[] {
-  const seen = new Set<string>();
-  const targets: LookupTarget[] = [];
+function buildPlayerTargets(players: readonly WoWPlayer[]): PlayerTarget[] {
+  const out: PlayerTarget[] = [];
   for (const p of players) {
+    if (!p.discordId) continue;
     const parsed = parseInGameName(p.inGameName);
     if (!parsed) continue;
     const key = `${DEFAULT_REGION}/${parsed.realmSlug}/${parsed.name.toLowerCase()}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    targets.push({ key, name: parsed.name, realm: parsed.realmSlug, region: DEFAULT_REGION });
+    out.push({
+      discordId: p.discordId,
+      key,
+      name: parsed.name,
+      realm: parsed.realmSlug,
+      region: DEFAULT_REGION,
+    });
   }
-  return targets;
+  return out;
 }
+
+function uniqueLookupsFor(playerTargets: readonly PlayerTarget[]): UniqueLookup[] {
+  const seen = new Set<string>();
+  const lookups: UniqueLookup[] = [];
+  for (const t of playerTargets) {
+    if (seen.has(t.key)) continue;
+    seen.add(t.key);
+    lookups.push({ key: t.key, name: t.name, realm: t.realm, region: t.region });
+  }
+  return lookups;
+}
+
+const EMPTY_SCORES_MAP: ReadonlyMap<string, CharacterDungeonScores | null> = new Map();
 
 /**
  * Fetch per-character M+ dungeon scores from Raider.io and compute a
  * group-level ranking projected at `keyLevel`.
  *
  * Refetches whenever:
- *   - The roster changes (new players, new linked characters)
+ *   - The roster of unique characters changes
  *   - `dungeonSuggestionsRefreshKey` in the store bumps (driven by spin start)
  *
  * Changes to `keyLevel` don't refetch — we re-aggregate the cached
- * per-character data via useMemo so changing the dropdown is instant.
+ * per-character data via useMemo so flipping the dropdown is instant.
  *
- * Players without a parseable `inGameName` (e.g. "Tytanium-Stormrage")
- * are skipped — the result reflects whoever has linkable characters.
+ * The hook returns both the aggregated `state` (consumed by the suggestions
+ * panel) and a `scoresByDiscordId` map (consumed by the spotlight portraits
+ * to show per-player score tooltips). Two consumers, one fetch.
  */
 export function useDungeonSuggestions(
   players: readonly WoWPlayer[],
   keyLevel: number,
-): DungeonSuggestionsState {
+): UseDungeonSuggestionsResult {
   const refreshKey = useAppStore((s) => s.dungeonSuggestionsRefreshKey);
   const [fetchState, setFetchState] = useState<FetchState>(IDLE_FETCH_STATE);
 
-  const targets = useMemo(() => buildLookupTargets(players), [players]);
-  const playersKey = useMemo(() => targets.map(t => t.key).sort().join('|'), [targets]);
+  const playerTargets = useMemo(() => buildPlayerTargets(players), [players]);
+  const uniqueLookups = useMemo(() => uniqueLookupsFor(playerTargets), [playerTargets]);
+  // Identity input for the fetch effect — the set of unique characters to fetch.
+  const lookupsKey = useMemo(
+    () => uniqueLookups.map(t => t.key).sort().join('|'),
+    [uniqueLookups],
+  );
 
   const abortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     abortRef.current?.abort();
 
-    if (targets.length === 0) {
+    if (uniqueLookups.length === 0) {
       setFetchState({ ...IDLE_FETCH_STATE, phase: 'no-targets' });
       return;
     }
 
     const controller = new AbortController();
     abortRef.current = controller;
-    setFetchState((s) => ({ ...s, phase: 'loading', lookupTargetCount: targets.length }));
+    setFetchState((s) => ({ ...s, phase: 'loading', lookupTargetCount: uniqueLookups.length }));
 
     let cancelled = false;
     Promise.allSettled(
-      targets.map(t =>
+      uniqueLookups.map(t =>
         fetchCharacterDungeonScores(t.name, t.realm, t.region, controller.signal),
       ),
     ).then((results) => {
@@ -124,11 +167,21 @@ export function useDungeonSuggestions(
         }
       }
 
+      const indexByKey: Record<string, number> = {};
+      uniqueLookups.forEach((l, i) => { indexByKey[l.key] = i; });
+
+      const characterIndexByDiscordId: Record<string, number> = {};
+      for (const t of playerTargets) {
+        const idx = indexByKey[t.key];
+        if (idx !== undefined) characterIndexByDiscordId[t.discordId] = idx;
+      }
+
       setFetchState({
         phase: 'fetched',
         characters,
+        characterIndexByDiscordId,
         serviceErrors,
-        lookupTargetCount: targets.length,
+        lookupTargetCount: uniqueLookups.length,
       });
     });
 
@@ -136,23 +189,32 @@ export function useDungeonSuggestions(
       cancelled = true;
       controller.abort();
     };
-    // playersKey + refreshKey are the identity inputs; re-run on either change.
+    // lookupsKey + refreshKey are the identity inputs; re-run on either change.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [playersKey, refreshKey]);
+  }, [lookupsKey, refreshKey]);
 
   // Re-aggregate whenever fetch state OR key level changes. Changing the
   // dropdown is a pure recomputation — no refetch.
-  return useMemo<DungeonSuggestionsState>(() => {
-    const { phase, characters, serviceErrors, lookupTargetCount } = fetchState;
+  return useMemo<UseDungeonSuggestionsResult>(() => {
+    const { phase, characters, characterIndexByDiscordId, serviceErrors, lookupTargetCount } = fetchState;
 
     if (phase === 'idle') {
-      return { status: 'idle', ranking: [], characterCount: 0, lookupTargetCount: 0 };
+      return {
+        state: { status: 'idle', ranking: [], characterCount: 0, lookupTargetCount: 0 },
+        scoresByDiscordId: EMPTY_SCORES_MAP,
+      };
     }
     if (phase === 'no-targets') {
-      return { status: 'empty', ranking: [], characterCount: 0, lookupTargetCount: 0 };
+      return {
+        state: { status: 'empty', ranking: [], characterCount: 0, lookupTargetCount: 0 },
+        scoresByDiscordId: EMPTY_SCORES_MAP,
+      };
     }
     if (phase === 'loading') {
-      return { status: 'loading', ranking: [], characterCount: 0, lookupTargetCount };
+      return {
+        state: { status: 'loading', ranking: [], characterCount: 0, lookupTargetCount },
+        scoresByDiscordId: EMPTY_SCORES_MAP,
+      };
     }
 
     // phase === 'fetched'
@@ -168,11 +230,19 @@ export function useDungeonSuggestions(
       status = 'empty';
     }
 
+    const scoresByDiscordId = new Map<string, CharacterDungeonScores | null>();
+    for (const [discordId, idx] of Object.entries(characterIndexByDiscordId)) {
+      scoresByDiscordId.set(discordId, characters[idx] ?? null);
+    }
+
     return {
-      status,
-      ranking,
-      characterCount: valid.length,
-      lookupTargetCount,
+      state: {
+        status,
+        ranking,
+        characterCount: valid.length,
+        lookupTargetCount,
+      },
+      scoresByDiscordId,
     };
   }, [fetchState, keyLevel]);
 }

--- a/activity/src/index.css
+++ b/activity/src/index.css
@@ -3266,6 +3266,120 @@ button.role-section-header--collapsible {
   flex-direction: column;
   align-items: center;
   width: 88px;
+  position: relative;
+}
+
+.spotlight-portrait--has-tooltip {
+  cursor: help;
+}
+
+.spotlight-portrait--has-tooltip:focus-visible {
+  outline: 2px solid var(--color-gold);
+  outline-offset: 4px;
+  border-radius: 4px;
+}
+
+/* Score tooltip — shows on hover/focus of the portrait when scores are
+   provided. Positioned above the portrait and centered; falls back to
+   translating off-screen with `visibility: hidden` so it's still in the
+   DOM for screen readers but not blocking pointer events. */
+.spotlight-portrait__tooltip {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  width: max-content;
+  max-width: 280px;
+  padding: 10px 12px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: 0.75rem;
+  text-align: left;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.45);
+  z-index: 20;
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.15s ease, visibility 0.15s ease;
+}
+
+.spotlight-portrait--has-tooltip:hover .spotlight-portrait__tooltip,
+.spotlight-portrait--has-tooltip:focus-within .spotlight-portrait__tooltip {
+  opacity: 1;
+  visibility: visible;
+}
+
+.spotlight-portrait__tooltip-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 6px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.spotlight-portrait__tooltip-name {
+  font-weight: 700;
+  color: var(--ch-color, var(--text-heading));
+  font-size: 0.85rem;
+}
+
+.spotlight-portrait__tooltip-overall {
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.spotlight-portrait__tooltip-overall strong {
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.spotlight-portrait__tooltip-overall-label {
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.spotlight-portrait__tooltip-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.spotlight-portrait__tooltip-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 10px;
+  align-items: baseline;
+}
+
+.spotlight-portrait__tooltip-dungeon {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.spotlight-portrait__tooltip-key {
+  color: var(--color-gold);
+  font-weight: 600;
+}
+
+.spotlight-portrait__tooltip-score {
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+.spotlight-portrait__tooltip-empty {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  font-style: italic;
 }
 
 .spotlight-portrait__stage {

--- a/activity/src/lib/dungeonSuggestions.test.ts
+++ b/activity/src/lib/dungeonSuggestions.test.ts
@@ -18,7 +18,16 @@ function makeChar(
       iconUrl: r.iconUrl ?? null,
     };
   }
-  return { name, realm: 'r', region: 'us', byDungeon };
+  return {
+    name,
+    realm: 'r',
+    region: 'us',
+    byDungeon,
+    overallScore: null,
+    scoreColor: null,
+    className: null,
+    specName: null,
+  };
 }
 
 describe('computeDungeonRanking', () => {

--- a/activity/src/services/raiderioMythicPlus.ts
+++ b/activity/src/services/raiderioMythicPlus.ts
@@ -22,6 +22,14 @@ export interface CharacterDungeonScores {
   region: string;
   /** Best run per dungeon, keyed by challenge_mode_id. */
   byDungeon: Record<number, DungeonRunSummary>;
+  /** Overall Raider.io M+ score for the current season ("all" segment), or null. */
+  overallScore: number | null;
+  /** Raider.io rarity color for the overall score (e.g. "#f06862"), or null. */
+  scoreColor: string | null;
+  /** Character's class name from Raider.io (e.g. "Mage"), or null. */
+  className: string | null;
+  /** Active spec name (e.g. "Frost"), or null. */
+  specName: string | null;
 }
 
 interface RaiderioRun {
@@ -33,14 +41,26 @@ interface RaiderioRun {
   icon_url?: string;
 }
 
+interface RaiderioSeasonScore {
+  season: string;
+  scores?: { all?: number };
+  segments?: { all?: { score?: number; color?: string } };
+}
+
 interface RaiderioMythicPlusResponse {
   name?: string;
   realm?: string;
+  class?: string;
+  active_spec_name?: string;
   mythic_plus_best_runs?: RaiderioRun[];
   mythic_plus_alternate_runs?: RaiderioRun[];
+  mythic_plus_scores_by_season?: RaiderioSeasonScore[];
 }
 
-const RAIDERIO_FIELDS = 'mythic_plus_best_runs,mythic_plus_alternate_runs';
+// `mythic_plus_scores_by_season:current` returns the current main season's
+// totals (overall + per-role + per-spec) plus their rarity color.
+const RAIDERIO_FIELDS =
+  'mythic_plus_best_runs,mythic_plus_alternate_runs,mythic_plus_scores_by_season:current';
 
 export class RaiderioFetchError extends Error {
   constructor(message: string, readonly cause?: unknown) {
@@ -124,10 +144,20 @@ export async function fetchCharacterDungeonScores(
     }
   }
 
+  // `:current` filter returns a single-element array (the current main season)
+  // when the character has any season activity. Defensive: treat missing as null.
+  const seasonEntry = data.mythic_plus_scores_by_season?.[0];
+  const overallScore = seasonEntry?.scores?.all ?? null;
+  const scoreColor = seasonEntry?.segments?.all?.color ?? null;
+
   return {
     name: data.name ?? name,
     realm: data.realm ?? realm,
     region,
     byDungeon,
+    overallScore: typeof overallScore === 'number' ? overallScore : null,
+    scoreColor: typeof scoreColor === 'string' ? scoreColor : null,
+    className: typeof data.class === 'string' ? data.class : null,
+    specName: typeof data.active_spec_name === 'string' ? data.active_spec_name : null,
   };
 }

--- a/activity/src/views/ResultsView.tsx
+++ b/activity/src/views/ResultsView.tsx
@@ -85,7 +85,8 @@ export function ResultsView({ onNavigate }: ResultsViewProps) {
   const handleKeyLevelChange = useCallback((next: number) => {
     setKeyLevel(clampKeyLevel(next));
   }, []);
-  const dungeonSuggestionsState = useDungeonSuggestions(suggestionsPlayers, keyLevel);
+  const { state: dungeonSuggestionsState, scoresByDiscordId } =
+    useDungeonSuggestions(suggestionsPlayers, keyLevel);
 
   const [showConfirmBack, setShowConfirmBack] = useState(false);
   const pendingBrowserBack = useAppStore((s) => s.pendingBrowserBack);
@@ -156,7 +157,10 @@ export function ResultsView({ onNavigate }: ResultsViewProps) {
           {yourGroupPlayers.length > 0 && (
             <div className="results-your-group">
               <h3 className="results-your-group__heading">{yourGroupHeading}</h3>
-              <SpotlightPortraits players={yourGroupPlayers} />
+              <SpotlightPortraits
+                players={yourGroupPlayers}
+                scoresByDiscordId={scoresByDiscordId}
+              />
             </div>
           )}
           <DungeonSuggestions

--- a/activity/tests/dungeonSuggestions.spec.ts
+++ b/activity/tests/dungeonSuggestions.spec.ts
@@ -56,6 +56,31 @@ test.describe('Dungeon Suggestions panel', () => {
     await expect(panel.locator('.dungeon-suggestions__empty')).toContainText(/Couldn't reach Raider\.io/i);
   });
 
+  test('hovering a spotlight portrait shows that character\'s M+ scores', async ({ page }) => {
+    await mockRaiderio(page);
+    const dataWithIdentity = {
+      ...resultsData,
+      identity: { id: mockPlayers[4].discordId, name: mockPlayers[4].name },
+    };
+    await page.goto(`/?data=${encodeData(dataWithIdentity)}`);
+    await expect(page.locator('#view-results')).toBeVisible();
+    await expect(page.locator('.spotlight-portrait')).toHaveCount(5);
+
+    // Wait for character data to settle so the tooltip has scores to show.
+    await expect(page.locator('.dungeon-suggestions__footnote')).toBeVisible();
+
+    const firstPortrait = page.locator('.spotlight-portrait').first();
+    const tooltip = firstPortrait.locator('.spotlight-portrait__tooltip');
+    // Hidden by default, but DOM-present so it's visible to assistive tech.
+    await expect(tooltip).toBeAttached();
+
+    await firstPortrait.hover();
+    await expect(tooltip).toBeVisible();
+    // Includes overall RIO + per-dungeon list seeded from the fixture.
+    await expect(tooltip).toContainText(/RIO/);
+    await expect(tooltip.locator('.spotlight-portrait__tooltip-row')).toHaveCount(8);
+  });
+
   test('renders empty-state when no players have a parseable inGameName', async ({ page }) => {
     await mockRaiderio(page);
     const stripInGameName = (p: typeof mockPlayers[number]) => ({ ...p, inGameName: undefined });

--- a/activity/tests/helpers/raiderio.ts
+++ b/activity/tests/helpers/raiderio.ts
@@ -22,9 +22,15 @@ const PLACEHOLDER_ICON =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkqAcAAIUAgUW0RjgAAAAASUVORK5CYII=';
 
 function buildPayload(name: string) {
+  // Sum of best-run scores → seed the season "all" total. Real Raider.io
+  // weights best/alt with 1.5x/0.5x; we don't model that here because the
+  // tooltip just displays whatever the API returns.
+  const totalScore = FIXTURE_RUNS.reduce((acc, r) => acc + r.score, 0);
   return {
     name,
     realm: 'Test',
+    class: 'Mage',
+    active_spec_name: 'Frost',
     mythic_plus_best_runs: FIXTURE_RUNS.map(f => ({
       dungeon: f.name,
       short_name: f.short,
@@ -35,6 +41,11 @@ function buildPayload(name: string) {
       affixes: [],
     })),
     mythic_plus_alternate_runs: [],
+    mythic_plus_scores_by_season: [{
+      season: 'season-tww-3',
+      scores: { all: totalScore, dps: totalScore, healer: 0, tank: 0 },
+      segments: { all: { score: totalScore, color: '#ff8000' } },
+    }],
   };
 }
 


### PR DESCRIPTION
## Summary

Hovering (or keyboard-focusing) a character's spotlight portrait on the Results page now reveals a tooltip with that character's overall Raider.io score and per-dungeon score breakdown — useful at a glance when sizing up the group before locking in a key.

## Implementation

- **One fetch, two consumers**: extended the existing per-character fetch with `mythic_plus_scores_by_season:current` (single extra `fields` value, no new HTTP request). `useDungeonSuggestions` now returns `{ state, scoresByDiscordId }`. The suggestions panel reads `state` like before; the spotlight portraits read `scoresByDiscordId`.
- **Optional in `SpotlightPortraits`**: the `scoresByDiscordId` prop is optional, so `SpotlightCard` (the wheel-reveal flow, which has no fetched data) keeps its existing behavior unchanged.
- **Tooltip UX**: hover/focus reveals; lives in the DOM with `role="tooltip"` and `aria-describedby`; portrait gets `tabIndex={0}` only when scores are present so it picks up keyboard focus.
- **Per-character data captured**: `CharacterDungeonScores` now carries `overallScore`, `scoreColor`, `className`, `specName` in addition to the per-dungeon breakdown.

## Test plan

- [x] `cd activity && npm run typecheck` — clean
- [x] `cd activity && npx vitest run` — 259 unit tests pass
- [x] `cd activity && npm run build` + `build-storybook` — clean
- [x] `./scripts/playwright-docker.sh --update-snapshots` — 160/160 (new "hovering a spotlight portrait" test included)
- [ ] Manually verify after deploy: hover each character's portrait on Results, confirm tooltip shows expected dungeons and overall RIO; tab through portraits with keyboard, confirm focus styling and tooltip appearance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)