### PR TITLE
chore(activity): add SpotlightPortrait stories with hover M+ tooltip

### DIFF
--- a/activity/src/components/SpotlightPortrait.stories.tsx
+++ b/activity/src/components/SpotlightPortrait.stories.tsx
@@ -1,6 +1,41 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { CHARACTER_CLASSES } from '@mythicplus/shared';
 import { SpotlightPortrait } from './SpotlightPortrait';
+import type { CharacterDungeonScores } from '../services/raiderioMythicPlus';
+
+// Realistic-looking sample so the hover/focus tooltip has something to show.
+// Edit `name`, `score`, `level`, and `iconUrl` here to preview different
+// score profiles in Storybook.
+const SAMPLE_SCORES: CharacterDungeonScores = {
+  name: 'Gazzi',
+  realm: 'Uldum',
+  region: 'us',
+  overallScore: 3214.5,
+  scoreColor: '#ff8000', // orange (epic-tier)
+  className: 'Druid',
+  specName: 'Guardian',
+  byDungeon: {
+    525: { challengeModeId: 525, name: 'Operation: Floodgate', shortName: 'FLOOD', level: 14, score: 412, iconUrl: 'https://cdn.raiderio.net/images/wow/icons/large/inv_achievement_dungeon_waterworks.jpg' },
+    542: { challengeModeId: 542, name: "Eco-Dome Al'dani", shortName: 'EDA', level: 13, score: 388, iconUrl: 'https://cdn.raiderio.net/images/wow/icons/large/inv_112_achievement_dungeon_ecodome.jpg' },
+    503: { challengeModeId: 503, name: 'Ara-Kara, City of Echoes', shortName: 'ARAK', level: 14, score: 421, iconUrl: 'https://cdn.raiderio.net/images/wow/icons/large/inv_achievement_dungeon_arak-ara.jpg' },
+    505: { challengeModeId: 505, name: 'The Dawnbreaker', shortName: 'DAWN', level: 12, score: 360, iconUrl: 'https://cdn.raiderio.net/images/wow/icons/large/inv_achievement_dungeon_dawnbreaker.jpg' },
+    499: { challengeModeId: 499, name: 'Priory of the Sacred Flame', shortName: 'PSF', level: 13, score: 395, iconUrl: 'https://cdn.raiderio.net/images/wow/icons/large/inv_achievement_dungeon_prioryofthesacredflame.jpg' },
+    378: { challengeModeId: 378, name: 'Halls of Atonement', shortName: 'HOA', level: 12, score: 358, iconUrl: 'https://cdn.raiderio.net/images/wow/icons/large/achievement_dungeon_hallsofattonement.jpg' },
+    391: { challengeModeId: 391, name: 'Tazavesh: Streets of Wonder', shortName: 'STRT', level: 13, score: 392, iconUrl: 'https://cdn.raiderio.net/images/wow/icons/large/achievement_dungeon_brokerdungeon.jpg' },
+    392: { challengeModeId: 392, name: "Tazavesh: So'leah's Gambit", shortName: 'GMBT', level: 14, score: 415, iconUrl: 'https://cdn.raiderio.net/images/wow/icons/large/achievement_dungeon_theotherside_dealergexa.jpg' },
+  },
+};
+
+const NEW_PLAYER_SCORES: CharacterDungeonScores = {
+  name: 'Freshalt',
+  realm: 'Uldum',
+  region: 'us',
+  overallScore: null,
+  scoreColor: null,
+  className: 'Hunter',
+  specName: 'Beast Mastery',
+  byDungeon: {},
+};
 
 const meta = {
   title: 'Atoms/SpotlightPortrait',
@@ -69,5 +104,30 @@ export const MissingAvatar: Story = {
     name: 'Tanky',
     characterClass: null,
     mediaUrl: null,
+  },
+};
+
+/**
+ * Hover (or tab to + focus) the portrait to reveal the M+ score tooltip.
+ * The tooltip shows the character's overall Raider.io score plus the
+ * per-dungeon breakdown sorted by best score, descending.
+ */
+export const WithScoresOnHover: Story = {
+  args: {
+    name: 'Gazzi',
+    characterClass: 'Druid',
+    mediaUrl: GAZZI_MEDIA,
+    scores: SAMPLE_SCORES,
+  },
+};
+
+/** A character with no recorded runs this season — tooltip shows the empty
+ *  state instead of an empty list. */
+export const WithScoresEmptySeason: Story = {
+  args: {
+    name: 'Freshalt',
+    characterClass: 'Hunter',
+    mediaUrl: 'https://render.worldofwarcraft.com/us/character/uldum/234/184140522-inset.jpg',
+    scores: NEW_PLAYER_SCORES,
   },
 };


### PR DESCRIPTION
## Summary

Adds two stories under \`Atoms/SpotlightPortrait\` so you can preview the new hover M+ score tooltip in Storybook without standing up a full session:

- **WithScoresOnHover** — full sample (overall RIO + all 8 current-season dungeons). Hover or tab-focus the portrait to see the tooltip.
- **WithScoresEmptySeason** — no runs / no overall score; exercises the "no timed runs yet this season" empty branch.

## Test plan

- [x] \`cd activity && npm run typecheck\` — clean
- [x] \`cd activity && npm run build-storybook\` — clean
- [ ] Open Storybook, navigate to \`Atoms/SpotlightPortrait/With Scores On Hover\`, hover the portrait, confirm tooltip styling matches the production Results page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)