### PR TITLE
fix(activity): keep portrait tooltip inside viewport via Floating UI

### DIFF
--- a/activity/package.json
+++ b/activity/package.json
@@ -19,6 +19,7 @@
   "type": "commonjs",
   "dependencies": {
     "@discord/embedded-app-sdk": "^2.4.0",
+    "@floating-ui/react": "^0.27.19",
     "@mythicplus/shared": "*",
     "@sentry/react": "^10.48.0",
     "@tailwindcss/vite": "^4.2.1",
@@ -46,10 +47,10 @@
     "@vitest/browser-playwright": "^4.1.0",
     "@vitest/coverage-v8": "^4.1.0",
     "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-storybook": "10.3.5",
     "playwright": "^1.58.2",
     "storybook": "^10.3.5",
-    "vitest": "^4.1.0",
-    "eslint-plugin-storybook": "10.3.5"
+    "vitest": "^4.1.0"
   },
   "optionalDependencies": {
     "@tailwindcss/oxide-linux-x64-gnu": "^4.2.1",

--- a/activity/src/components/SpotlightPortrait.tsx
+++ b/activity/src/components/SpotlightPortrait.tsx
@@ -1,4 +1,18 @@
-import { useId, useState } from 'react';
+import { useState } from 'react';
+import {
+  FloatingPortal,
+  autoUpdate,
+  flip,
+  offset,
+  shift,
+  useDismiss,
+  useFloating,
+  useFocus,
+  useHover,
+  useInteractions,
+  useRole,
+  useTransitionStyles,
+} from '@floating-ui/react';
 import type { CharacterClass } from '@mythicplus/shared';
 import type { CharacterDungeonScores } from '../services/raiderioMythicPlus';
 import { remapImageUrl } from '../discordSdk';
@@ -14,6 +28,7 @@ interface SpotlightPortraitProps {
 }
 
 const DEFAULT_COLOR = '#808080';
+const VIEWPORT_PADDING = 8;
 
 function FallbackAvatar({ color }: { color: string }) {
   return (
@@ -33,16 +48,31 @@ export function SpotlightPortrait({ name, characterClass, mediaUrl, scores }: Sp
   const color = getClassColor(characterClass) ?? DEFAULT_COLOR;
   const [failed, setFailed] = useState(false);
   const showImage = proxiedUrl && !failed;
-  const tooltipId = useId();
   const hasTooltip = Boolean(scores);
+
+  const [isOpen, setIsOpen] = useState(false);
+  const { refs, floatingStyles, context } = useFloating({
+    open: isOpen,
+    onOpenChange: setIsOpen,
+    placement: 'top',
+    middleware: [offset(8), flip({ padding: VIEWPORT_PADDING }), shift({ padding: VIEWPORT_PADDING })],
+    whileElementsMounted: autoUpdate,
+  });
+  const hover = useHover(context, { enabled: hasTooltip, move: false });
+  const focus = useFocus(context, { enabled: hasTooltip });
+  const dismiss = useDismiss(context, { enabled: hasTooltip });
+  const role = useRole(context, { role: 'tooltip' });
+  const { getReferenceProps, getFloatingProps } = useInteractions([hover, focus, dismiss, role]);
+  const { isMounted, styles: transitionStyles } = useTransitionStyles(context, { duration: 150 });
 
   return (
     <div
+      ref={refs.setReference}
       className={`spotlight-portrait${hasTooltip ? ' spotlight-portrait--has-tooltip' : ''}`}
       style={{ '--ch-color': color } as React.CSSProperties}
       title={hasTooltip ? undefined : name}
       tabIndex={hasTooltip ? 0 : undefined}
-      aria-describedby={hasTooltip ? tooltipId : undefined}
+      {...getReferenceProps()}
     >
       <div className="spotlight-portrait__stage">
         {showImage ? (
@@ -57,20 +87,28 @@ export function SpotlightPortrait({ name, characterClass, mediaUrl, scores }: Sp
         )}
         <div className="spotlight-portrait__name">{name}</div>
       </div>
-      {hasTooltip && scores && (
-        <ScoreTooltip id={tooltipId} name={name} scores={scores} />
+      {hasTooltip && scores && isMounted && (
+        <FloatingPortal>
+          <div
+            ref={refs.setFloating}
+            className="spotlight-portrait__tooltip"
+            style={{ ...floatingStyles, ...transitionStyles, '--ch-color': color } as React.CSSProperties}
+            {...getFloatingProps()}
+          >
+            <ScoreTooltipBody name={name} scores={scores} />
+          </div>
+        </FloatingPortal>
       )}
     </div>
   );
 }
 
-interface ScoreTooltipProps {
-  id: string;
+interface ScoreTooltipBodyProps {
   name: string;
   scores: CharacterDungeonScores;
 }
 
-function ScoreTooltip({ id, name, scores }: ScoreTooltipProps) {
+function ScoreTooltipBody({ name, scores }: ScoreTooltipBodyProps) {
   // Per-dungeon entries sorted by best score, descending — highest first
   // matches what the player would expect to see on their Raider.io page.
   const dungeons = Object.values(scores.byDungeon)
@@ -78,7 +116,7 @@ function ScoreTooltip({ id, name, scores }: ScoreTooltipProps) {
     .sort((a, b) => b.score - a.score);
 
   return (
-    <div role="tooltip" id={id} className="spotlight-portrait__tooltip">
+    <>
       <div className="spotlight-portrait__tooltip-header">
         <span className="spotlight-portrait__tooltip-name">{name}</span>
         <span className="spotlight-portrait__tooltip-overall">
@@ -111,6 +149,6 @@ function ScoreTooltip({ id, name, scores }: ScoreTooltipProps) {
       ) : (
         <p className="spotlight-portrait__tooltip-empty">No timed runs yet this season.</p>
       )}
-    </div>
+    </>
   );
 }

--- a/activity/src/index.css
+++ b/activity/src/index.css
@@ -3280,14 +3280,9 @@ button.role-section-header--collapsible {
 }
 
 /* Score tooltip — shows on hover/focus of the portrait when scores are
-   provided. Positioned above the portrait and centered; falls back to
-   translating off-screen with `visibility: hidden` so it's still in the
-   DOM for screen readers but not blocking pointer events. */
+   provided. Positioning (placement, flip, viewport-shift) is handled by
+   Floating UI via inline styles; this rule only controls appearance. */
 .spotlight-portrait__tooltip {
-  position: absolute;
-  bottom: calc(100% + 8px);
-  left: 50%;
-  transform: translateX(-50%);
   width: max-content;
   max-width: 280px;
   padding: 10px 12px;
@@ -3300,15 +3295,6 @@ button.role-section-header--collapsible {
   box-shadow: 0 4px 14px rgba(0, 0, 0, 0.45);
   z-index: 20;
   pointer-events: none;
-  opacity: 0;
-  visibility: hidden;
-  transition: opacity 0.15s ease, visibility 0.15s ease;
-}
-
-.spotlight-portrait--has-tooltip:hover .spotlight-portrait__tooltip,
-.spotlight-portrait--has-tooltip:focus-within .spotlight-portrait__tooltip {
-  opacity: 1;
-  visibility: visible;
 }
 
 .spotlight-portrait__tooltip-header {

--- a/activity/tests/dungeonSuggestions.spec.ts
+++ b/activity/tests/dungeonSuggestions.spec.ts
@@ -70,9 +70,10 @@ test.describe('Dungeon Suggestions panel', () => {
     await expect(page.locator('.dungeon-suggestions__footnote')).toBeVisible();
 
     const firstPortrait = page.locator('.spotlight-portrait').first();
-    const tooltip = firstPortrait.locator('.spotlight-portrait__tooltip');
-    // Hidden by default, but DOM-present so it's visible to assistive tech.
-    await expect(tooltip).toBeAttached();
+    // Tooltip is rendered via FloatingPortal at the document root and only
+    // mounts while the trigger is hovered/focused.
+    const tooltip = page.locator('.spotlight-portrait__tooltip');
+    await expect(tooltip).toHaveCount(0);
 
     await firstPortrait.hover();
     await expect(tooltip).toBeVisible();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,9 @@
 {
-  "name": "MythicPlusDiscordBot",
+  "name": "robust-imagining-key",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "MythicPlusDiscordBot",
       "workspaces": [
         "packages/*",
         "activity"
@@ -22,6 +21,7 @@
       "license": "ISC",
       "dependencies": {
         "@discord/embedded-app-sdk": "^2.4.0",
+        "@floating-ui/react": "^0.27.19",
         "@mythicplus/shared": "*",
         "@sentry/react": "^10.48.0",
         "@tailwindcss/vite": "^4.2.1",
@@ -2619,6 +2619,59 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.19",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.19.tgz",
+      "integrity": "sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@google-cloud/firestore": {
       "version": "7.11.6",
@@ -10622,6 +10675,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "license": "MIT"
     },
     "node_modules/teeny-request": {
       "version": "9.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "robust-imagining-key",
+  "name": "MythicPlusDiscordBot",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
## Summary
- Edge-positioned spotlight portraits (group 1's leftmost char, group N's rightmost) clipped the M+ score tooltip off-screen because it was a fixed-offset absolute child.
- Replaced the hand-rolled positioning with \`@floating-ui/react\`: \`offset(8) + flip({ padding: 8 }) + shift({ padding: 8 })\`, so the tooltip slides to stay inside the viewport and flips below the portrait if there's no room above.
- Tooltip now renders through \`FloatingPortal\` (escapes ancestor overflow) and only mounts while open via the standard hover/focus/dismiss/role pattern.
- Preserved the 150ms fade via \`useTransitionStyles\`.

## Test plan
- [x] \`npx tsc --noEmit\` (activity)
- [x] \`npm -w activity run build\`
- [x] \`./scripts/playwright-docker.sh\` — all 160 tests pass, including the updated \`hovering a spotlight portrait shows that character's M+ scores\` test (now queries the portaled tooltip at page level)
- [ ] Manual spot-check in the activity: hover the leftmost and rightmost portraits — tooltip stays fully on-screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)