### PR TITLE
fix(wheel): remove portrait reveal animation after landing

### DIFF
--- a/activity/src/components/Wheel.stories.tsx
+++ b/activity/src/components/Wheel.stories.tsx
@@ -193,8 +193,8 @@ export const OffspecVsMainspecComparison: Story = {
   },
 };
 
-export const LandedWithPortrait: Story = {
-  name: 'Landed — winner with portrait',
+export const LandedTank: Story = {
+  name: 'Landed — winner highlighted',
   args: {
     role: 'tank',
     label: 'Tank',
@@ -203,12 +203,11 @@ export const LandedWithPortrait: Story = {
     initialEntries: TANK_POOL,
     initialRotation: FIXED_ROTATION,
     initialWinner: 'Gazzi',
-    initialRevealed: true,
   },
 };
 
-export const LandedMageWinner: Story = {
-  name: 'Landed — Mage (class color border)',
+export const LandedDps: Story = {
+  name: 'Landed — DPS winner',
   args: {
     role: 'dps1',
     label: 'DPS',
@@ -217,12 +216,11 @@ export const LandedMageWinner: Story = {
     initialEntries: DPS_POOL,
     initialRotation: FIXED_ROTATION,
     initialWinner: 'Tytaniormu',
-    initialRevealed: true,
   },
 };
 
-export const LandedFallback: Story = {
-  name: 'Landed — no image (fallback glyph)',
+export const LandedHealer: Story = {
+  name: 'Landed — Healer winner',
   args: {
     role: 'healer',
     label: 'Healer',
@@ -231,7 +229,6 @@ export const LandedFallback: Story = {
     initialEntries: HEALER_POOL,
     initialRotation: FIXED_ROTATION,
     initialWinner: 'Holymoly',
-    initialRevealed: true,
   },
 };
 
@@ -276,7 +273,7 @@ function SpinningHarness({ args }: { args: WheelProps }) {
 
 /**
  * Interactive play story — click "Spin" to trigger a real WAAPI spin.
- * Useful for manual QA of the end-to-end animation + portrait reveal.
+ * Useful for manual QA of the end-to-end animation.
  */
 export const InteractiveSpin: Story = {
   name: 'Interactive — click to spin',

--- a/activity/src/components/Wheel.tsx
+++ b/activity/src/components/Wheel.tsx
@@ -6,14 +6,10 @@ import {
   useMemo,
   useRef,
   useState,
-  type CSSProperties,
 } from 'react';
 import { WheelEntry } from '../types';
 import { audio } from '../lib/audio';
-import { toAvatarUrl } from '../lib/characterMedia';
-import { remapImageUrl } from '../discordSdk';
-import { getClassColor, getSliceColors } from '../lib/classColors';
-import { PORTRAIT_EXPAND_DURATION, PORTRAIT_REVEAL_DELAY } from '../lib/timing';
+import { getSliceColors } from '../lib/classColors';
 import {
   EASE_OUT_CUBIC_CSS,
   computeTickTimes,
@@ -39,11 +35,11 @@ export interface WheelHandle {
   init(entries: WheelEntry[]): void;
   /** Replace entries without resetting rotation or result. */
   updateEntries(entries: WheelEntry[]): void;
-  /** Animate to land on the named winner. Resolves after portrait reveal. */
+  /** Animate to land on the named winner. Resolves once the wheel has stopped. */
   spinTo(winnerName: string, duration?: number): Promise<string>;
   /** Cancel an in-flight spin, rejecting its promise. */
   cancel(): void;
-  /** Clear the result text + winner highlight + portrait. */
+  /** Clear the result text + winner highlight. */
   clearResult(): void;
   /** Toggle the spinning CSS state (pulse glow). spinTo manages this internally. */
   setSpinning(value: boolean): void;
@@ -56,11 +52,10 @@ export interface WheelProps {
   label: string;
   labelClass: WheelLabelClass;
   ariaLabel: string;
-  /** Storybook / test hook: initial entries + rotation + revealed winner. */
+  /** Storybook / test hook: initial entries + rotation + winner. */
   initialEntries?: WheelEntry[];
   initialRotation?: number;
   initialWinner?: string | null;
-  initialRevealed?: boolean;
 }
 
 export const Wheel = forwardRef<WheelHandle, WheelProps>(function Wheel(
@@ -72,14 +67,12 @@ export const Wheel = forwardRef<WheelHandle, WheelProps>(function Wheel(
     initialEntries,
     initialRotation,
     initialWinner = null,
-    initialRevealed = false,
   },
   ref,
 ) {
   const [entries, setEntries] = useState<WheelEntry[]>(initialEntries ?? []);
   const [rotation, setRotation] = useState(() => initialRotation ?? Math.random() * 2 * Math.PI);
   const [winnerName, setWinnerName] = useState<string | null>(initialWinner);
-  const [isRevealed, setIsRevealed] = useState(initialRevealed);
   const [isSpinning, setIsSpinning] = useState(false);
 
   const rootRef = useRef<HTMLDivElement | null>(null);
@@ -131,7 +124,6 @@ export const Wheel = forwardRef<WheelHandle, WheelProps>(function Wheel(
         setEntries(next);
         setRotation(Math.random() * 2 * Math.PI);
         setWinnerName(null);
-        setIsRevealed(false);
         setIsSpinning(false);
       },
       updateEntries(next) {
@@ -181,7 +173,6 @@ export const Wheel = forwardRef<WheelHandle, WheelProps>(function Wheel(
 
         setIsSpinning(true);
         setWinnerName(null);
-        setIsRevealed(false);
 
         const rotator = rotatorRef.current;
         if (!rotator) {
@@ -189,7 +180,6 @@ export const Wheel = forwardRef<WheelHandle, WheelProps>(function Wheel(
           setRotation(adjusted);
           setWinnerName(name);
           setIsSpinning(false);
-          setIsRevealed(true);
           return name;
         }
 
@@ -226,25 +216,9 @@ export const Wheel = forwardRef<WheelHandle, WheelProps>(function Wheel(
               setRotation(adjusted);
               setWinnerName(name);
               setIsSpinning(false);
-              // Audio fires immediately so the "pop" lands on the visible stop;
-              // the portrait reveal is delayed for a more deliberate beat.
               audio.land();
-
-              // Track these timeouts so a subsequent cancel/init clears them
-              // and they can't fire setIsRevealed/resolve after the wheel has
-              // already been reset. rejectSpinRef stays populated until the
-              // resolveTimeout fires so a cancel during the reveal delay still
-              // rejects the promise instead of leaking it.
-              const revealTimeout = window.setTimeout(() => {
-                // Trigger portrait CSS transition on the next frame so the
-                // transform: scale(0) → scale(1) actually fires.
-                requestAnimationFrame(() => setIsRevealed(true));
-              }, PORTRAIT_REVEAL_DELAY);
-              const resolveTimeout = window.setTimeout(() => {
-                rejectSpinRef.current = null;
-                resolve(name);
-              }, PORTRAIT_REVEAL_DELAY + PORTRAIT_EXPAND_DURATION);
-              tickTimeoutsRef.current.push(revealTimeout, resolveTimeout);
+              rejectSpinRef.current = null;
+              resolve(name);
             })
             .catch(() => {
               // Animation was cancelled — rejection is handled by cancelInFlight.
@@ -260,7 +234,6 @@ export const Wheel = forwardRef<WheelHandle, WheelProps>(function Wheel(
       },
       clearResult() {
         setWinnerName(null);
-        setIsRevealed(false);
       },
       setSpinning(value) {
         setIsSpinning(value);
@@ -285,8 +258,6 @@ export const Wheel = forwardRef<WheelHandle, WheelProps>(function Wheel(
       : entries.length > 0
         ? `${ariaLabel}. ${entries.length} candidates.`
         : ariaLabel;
-
-  const winnerEntry = winnerIndex !== null ? entries[winnerIndex] : null;
 
   return (
     <div
@@ -455,7 +426,6 @@ export const Wheel = forwardRef<WheelHandle, WheelProps>(function Wheel(
             />
           )}
         </svg>
-        <WinnerPortrait entry={winnerEntry} revealed={isRevealed} />
       </div>
       <div
         id={`result-${role}`}
@@ -468,51 +438,4 @@ export const Wheel = forwardRef<WheelHandle, WheelProps>(function Wheel(
   );
 });
 
-function WinnerPortrait({
-  entry,
-  revealed,
-}: {
-  entry: WheelEntry | null;
-  revealed: boolean;
-}) {
-  const [imgFailed, setImgFailed] = useState(false);
-
-  useEffect(() => {
-    setImgFailed(false);
-  }, [entry?.name, entry?.mediaUrl]);
-
-  // The outer div is always mounted so that its `transform: scale(0)` state
-  // is painted before the `is-revealing` class flips it to scale(1) —
-  // otherwise the mount and the class change commit in the same paint and
-  // the CSS transition is skipped.
-  const classColor = entry ? getClassColor(entry.characterClass) : null;
-  const avatarUrl = entry ? toAvatarUrl(entry.mediaUrl) : null;
-  const proxied = avatarUrl ? remapImageUrl(avatarUrl) : null;
-  const showImg = Boolean(proxied) && !imgFailed;
-  const fallbackGlyph = entry ? entry.name.charAt(0).toUpperCase() || '?' : '';
-
-  const style = classColor
-    ? ({ '--wp-color': classColor } as CSSProperties)
-    : undefined;
-
-  return (
-    <div
-      className={`wheel-portrait${revealed && entry ? ' is-revealing' : ''}`}
-      style={style}
-      aria-hidden="true"
-    >
-      {entry && showImg && (
-        <img
-          className="wheel-portrait__img"
-          src={proxied ?? undefined}
-          alt=""
-          onError={() => setImgFailed(true)}
-        />
-      )}
-      {entry && !showImg && (
-        <div className="wheel-portrait__fallback">{fallbackGlyph}</div>
-      )}
-    </div>
-  );
-}
 

--- a/activity/src/index.css
+++ b/activity/src/index.css
@@ -1294,69 +1294,6 @@ button:focus-visible,
   stroke-width: 0.3;
 }
 
-/* ============================================
-   Wheel portrait reveal (post-land animation)
-   ============================================ */
-.wheel-portrait {
-  /* transform duration must match PORTRAIT_EXPAND_DURATION in timing.ts (200ms).
-     Sized to the canvas's rendered square so the portrait's outer edge can
-     align with the wheel's gold ring, rather than the frame's bounding box. */
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  margin: auto;
-  aspect-ratio: 1 / 1;
-  max-width: 100%;
-  max-height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  pointer-events: none;
-  transform: scale(0);
-  opacity: 0;
-  transition:
-    transform 200ms ease-out,
-    opacity 150ms ease-out;
-  z-index: 3;
-}
-
-.wheel-portrait.is-revealing {
-  transform: scale(1);
-  opacity: 1;
-}
-
-.wheel-portrait__img,
-.wheel-portrait__fallback {
-  /* 94% matches the wheel's drawn radius (canvas radius = size/2 - size*0.03). */
-  width: 94%;
-  height: 94%;
-  box-sizing: border-box;
-  border-radius: 50%;
-  border: 4px solid var(--wp-color, var(--color-gold));
-  box-shadow:
-    0 0 24px color-mix(in srgb, var(--wp-color, var(--color-gold)) 40%, transparent),
-    0 8px 24px rgba(0, 0, 0, 0.55);
-  background: #0d0d1a;
-}
-
-.wheel-portrait__img {
-  object-fit: cover;
-}
-
-.wheel-portrait__fallback {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-family: 'Inter', sans-serif;
-  font-weight: 800;
-  font-size: clamp(32px, 18%, 80px);
-  color: var(--wp-color, #fff);
-  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.8);
-  background: color-mix(in srgb, var(--wp-color, var(--color-gold)) 22%, #0d0d1a);
-}
-
 /* Pointer / arrow at top of wheel — scales with wheel via container query units */
 .wheel-pointer {
   position: absolute;

--- a/activity/src/lib/timing.ts
+++ b/activity/src/lib/timing.ts
@@ -2,26 +2,16 @@
 export const CAROUSEL_SPIN_DURATION = 2000;   // ms per wheel in carousel mode
 export const CAROUSEL_ADVANCE_DELAY = 400;    // ms pause after each landing
 // Per-wheel spin durations in grid mode, ordered tank → healer → dps1/2/3.
-// Each wheel lands 300ms after the previous so portrait reveals are
+// Each wheel lands 300ms after the previous so landings are
 // individually visible instead of clumping into a single pop.
 export const GRID_SPIN_DURATIONS = [3000, 3300, 3600, 3900, 4200];
-
-// Beat between the wheel stopping and the portrait beginning to expand.
-// audio.land() still fires the moment the wheel stops (synced with the
-// animation), so the "pop" sound and the visible stop happen together;
-// the portrait reveal trails by this much for a more deliberate feel.
-export const PORTRAIT_REVEAL_DELAY = 250;     // ms gap between wheel stop and portrait reveal
-
-// Portrait reveal timing — must match the `transition: transform ... ms`
-// duration in .wheel-portrait CSS.
-export const PORTRAIT_EXPAND_DURATION = 200;  // ms for portrait scale-in animation
 
 // Auto-advance spotlight timing
 export const SPOTLIGHT_HOLD_DURATION = 1500;  // ms to hold spotlight card center-stage
 export const SPOTLIGHT_ENTER_DURATION = 500;  // ms for spotlight card enter animation
 export const SPOTLIGHT_EXIT_DURATION = 400;   // ms for spotlight card exit animation
 export const WHEELS_FADE_DURATION = 350;      // ms for wheels fade in/out
-export const POST_LAND_PAUSE = 700;           // ms pause after wheels land (holds portrait tableau)
+export const POST_LAND_PAUSE = 700;           // ms pause after wheels land before transitioning
 export const PROGRESS_FADE_DURATION = 200;    // ms for progress text cross-fade
 
 export function delay(ms: number): Promise<void> {


### PR DESCRIPTION
## Summary
- Drop the `WinnerPortrait` overlay that scales the character avatar over the wheel after it lands — the transition felt too distracting after each spin.
- Wheel now just stops on the winning slice with the existing class-colored highlight + result text. The character avatar still appears on the spotlight card that follows, so winners are not losing portrait representation overall.
- Removes the `PORTRAIT_REVEAL_DELAY` and `PORTRAIT_EXPAND_DURATION` timing constants and the `.wheel-portrait*` CSS that supported the reveal.

## Test plan
- [x] `npm run build` (activity)
- [x] Playwright snapshot suite (`./scripts/playwright-docker.sh`) — all 160 tests pass; no committed snapshots needed updating since prior snapshots only captured idle / spinning-ready states.
- [ ] Manual smoke: spin a real lobby and confirm the wheel lands cleanly with no avatar overlay popping in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)