### PR TITLE
chore: bootstrap agent-memory/

### DIFF
--- a/agent-memory/README.md
+++ b/agent-memory/README.md
@@ -1,0 +1,23 @@
+# agent-memory/
+
+Persistent state for the `/overnight` autonomous improvement skill.
+
+This directory is **checked into git on purpose**. It accumulates the agent's understanding of the codebase across runs, lessons from past attempts, and decisions that should not be re-litigated.
+
+## Files
+
+- `codebase-map.md` — the agent's evolving model of the architecture. Read at the start of each run.
+- `style-decisions.md` — consistency choices that have been made. **These are LAW.** The agent never reproposes anything contradicting these.
+- `avoid-list.md` — refactors that were attempted and failed. Entries have a 7-day TTL — older entries are pruned by the historian.
+- `open-backlog.md` — known issues found by past runs but not yet addressed. Pre-seeded into each new run as findings.
+- `summaries/` — one markdown file per overnight run. Permanent record. Read the most recent few at the start of each run.
+
+## Editing
+
+You (Tyler) can edit any of these manually to steer the agent — for example, to add a style decision the agent should follow, or to add an item to the avoid list. The agent will read your changes on the next run.
+
+The agent writes most of its updates via the historian role at the end of each run.
+
+## What's NOT in here
+
+Runtime state (the per-run backlog of proposals being deliberated, PR counters, deadlines) lives in `/tmp/overnight-<RUN_ID>/` outside the repo and is deleted at the end of each run.

--- a/agent-memory/avoid-list.md
+++ b/agent-memory/avoid-list.md
@@ -1,0 +1,7 @@
+# Avoid list
+
+Things tried and failed. Entries dated within the last 7 days are active. Older entries are pruned by the historian.
+
+Format: `- <YYYY-MM-DD>: <what was tried> failed because <reason>. PR: #<N>.`
+
+(empty — first run will populate this)

--- a/agent-memory/codebase-map.md
+++ b/agent-memory/codebase-map.md
@@ -1,0 +1,5 @@
+# Codebase map
+
+The agent's evolving understanding of this codebase's architecture. Updated by the historian after each /overnight run.
+
+(empty — first run will populate this)

--- a/agent-memory/open-backlog.md
+++ b/agent-memory/open-backlog.md
@@ -1,0 +1,5 @@
+# Open backlog
+
+Known issues found by past runs but not yet addressed. Pre-seeded into each new run as critic findings.
+
+(empty — first run will populate this)

--- a/agent-memory/style-decisions.md
+++ b/agent-memory/style-decisions.md
@@ -1,0 +1,7 @@
+# Style decisions
+
+Consistency and pattern choices the agent has standardized on. These are LAW — never re-litigate.
+
+Format: `- <YYYY-MM-DD>: <decision>. Rationale: <one line>. PR: #<N>.`
+
+(empty — first run will populate this)


### PR DESCRIPTION
## Summary
- Adds `agent-memory/` scaffold used by the `/overnight` autonomous improvement skill
- Creates README, codebase-map, style-decisions, avoid-list, open-backlog, and summaries/ directory
- This is the first PR of overnight run `20260427-063034`

## Test plan
- [x] No code changes — scaffold only
- [x] CI lint/typecheck/test should pass since no source touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)