### PR TITLE
refactor(types): drop unsafe casts in DiscordMember, sessionService, history

### DIFF
--- a/activity/src/services/firestoreService.ts
+++ b/activity/src/services/firestoreService.ts
@@ -36,7 +36,7 @@ function parseExistingRounds(
   if (!history || history.date !== todayIso || !Array.isArray(history.rounds)) {
     return [];
   }
-  return (history.rounds as unknown[]).map((r) => {
+  return history.rounds.map((r) => {
     if (r && typeof r === 'object' && 'groups' in r && Array.isArray((r as { groups: unknown }).groups)) {
       return (r as { groups: Record<string, unknown>[] }).groups;
     }

--- a/activity/src/types.ts
+++ b/activity/src/types.ts
@@ -24,7 +24,10 @@ export interface GuildData {
   voiceChannels: VoiceChannel[];
   groupHistory?: {
     date: string;
-    rounds: Record<string, unknown>[][];
+    // Stored as either flat `Record<string, unknown>[][]` (legacy) or
+    // `{ groups: Record<string, unknown>[] }[]` (current). Always read
+    // through parseExistingRounds() in firestoreService.ts to normalize.
+    rounds: unknown[];
   };
   refreshRequest?: unknown;
   createdAt: unknown;

--- a/packages/bot/src/commands/groups.ts
+++ b/packages/bot/src/commands/groups.ts
@@ -1,4 +1,4 @@
-import { SessionService, type Bot, type Guild, type VoiceChannel } from '../services/sessionService.js';
+import { SessionService, type Bot, type Guild } from '../services/sessionService.js';
 import type { GroupService } from '../services/groupService.js';
 import { reportBadGroup } from '../core/issues.js';
 import { ACTIVITY_URL, DISCORD_APPLICATION_ID } from '../core/config.js';

--- a/packages/bot/src/commands/groups.ts
+++ b/packages/bot/src/commands/groups.ts
@@ -29,12 +29,7 @@ export interface GroupsContext {
 }
 
 export type ActivityContext = Omit<GroupsContext, 'guild'> & {
-  guild: {
-    id: string;
-    name: string;
-    icon?: { url: string } | null;
-    voice_channels: VoiceChannel[];
-  } | null;
+  guild: Guild | null;
 };
 
 export interface VoiceState {

--- a/packages/bot/src/core/utils.ts
+++ b/packages/bot/src/core/utils.ts
@@ -16,6 +16,7 @@ export interface DiscordMember {
   nick?: string | null;
   global_name?: string | null;
   id: string;
+  bot: boolean;
   toString(): string;
 }
 

--- a/packages/bot/src/services/groupService.ts
+++ b/packages/bot/src/services/groupService.ts
@@ -34,9 +34,7 @@ export class GroupService {
     if (debug) {
       players = getDebugPlayers();
     } else {
-      const members = ctx.channel.members.filter(
-        (m) => !(m as unknown as { bot: boolean }).bot,
-      );
+      const members = ctx.channel.members.filter((m) => !m.bot);
       if (members.length === 0) {
         await ctx.send('❌ No players found in the channel.');
         return null;

--- a/packages/bot/src/services/sessionService.ts
+++ b/packages/bot/src/services/sessionService.ts
@@ -58,7 +58,7 @@ export class SessionService {
 
   async getOrCreateSession(
     ctx: {
-      guild: { id: string; name: string; icon?: { url: string } | null; voice_channels: VoiceChannel[] } | null;
+      guild: Guild | null;
       author: { voice?: { channel?: { id: string; name: string } | null } | null };
     },
     debug = false,
@@ -77,7 +77,7 @@ export class SessionService {
     );
     this.activeGuilds.add(guildId);
 
-    await this.refreshGuildVoiceChannels(ctx.guild as unknown as Guild);
+    await this.refreshGuildVoiceChannels(ctx.guild);
 
     const voiceChannelId = ctx.author.voice?.channel?.id ?? null;
     const voiceChannelName = ctx.author.voice?.channel?.name ?? '';
@@ -96,7 +96,7 @@ export class SessionService {
       guildId,
     });
 
-    await this.updateChannelPlayers(voiceChannelId, ctx.guild as unknown as Guild);
+    await this.updateChannelPlayers(voiceChannelId, ctx.guild);
 
     return [guildDocId, channelDocId];
   }

--- a/packages/bot/tests/utils.test.ts
+++ b/packages/bot/tests/utils.test.ts
@@ -32,6 +32,7 @@ describe('getWowName', () => {
       nick: 'Nick.Name',
       global_name: 'Global.Name',
       id: '1',
+      bot: false,
       toString: () => 'User.Name',
     };
     expect(getWowName(member1)).toBe('NickName');
@@ -41,6 +42,7 @@ describe('getWowName', () => {
       nick: null,
       global_name: 'Global.Name',
       id: '2',
+      bot: false,
       toString: () => 'User.Name',
     };
     expect(getWowName(member2)).toBe('GlobalName');
@@ -50,6 +52,7 @@ describe('getWowName', () => {
       nick: null,
       global_name: null,
       id: '3',
+      bot: false,
       toString: () => 'User.Name',
     };
     expect(getWowName(member3)).toBe('UserName');
@@ -78,9 +81,9 @@ describe('getPlayerList', () => {
     vi.mocked(mockSvc.getPreferenceByNameSync).mockReturnValue(null);
 
     const members: DiscordMember[] = [
-      { nick: 'SavedPlayer', id: '111', toString: () => 'SavedPlayer' },
-      { nick: 'NoRolesPlayer', id: '222', toString: () => 'NoRolesPlayer' },
-      { nick: 'AnotherPlayer', id: '333', toString: () => 'AnotherPlayer' },
+      { nick: 'SavedPlayer', id: '111', bot: false, toString: () => 'SavedPlayer' },
+      { nick: 'NoRolesPlayer', id: '222', bot: false, toString: () => 'NoRolesPlayer' },
+      { nick: 'AnotherPlayer', id: '333', bot: false, toString: () => 'AnotherPlayer' },
     ];
 
     const players = getPlayerList(members);


### PR DESCRIPTION
## Summary
- Adds \`bot: boolean\` to \`DiscordMember\` and removes the \`(m as unknown as { bot: boolean }).bot\` cast in \`groupService\`. Every \`adaptMember()\` call already supplies the field.
- Replaces the inline \`ctx.guild\` type with \`Guild | null\` in \`SessionService.getOrCreateSession\` and \`ActivityContext\`, removing two \`as unknown as Guild\` double-casts.
- Loosens \`GuildData.groupHistory.rounds\` to \`unknown[]\` (its true Firestore shape — legacy flat OR \`{ groups: [...] }\`-wrapped). Callers go through \`parseExistingRounds()\` to normalize.

## Test plan
- [x] \`npm -w packages/bot run typecheck\`
- [x] \`npm -w activity run typecheck\`
- [x] \`npm -w packages/bot run test\` (233 tests pass)

🤖 Generated by /overnight run 20260427-063034