### PR TITLE
chore(dead-code): drop SetupView duplicate, FORT_TYRAN_AFFIXES export, deleteTracking

### DIFF
--- a/activity/src/views/SetupView.tsx
+++ b/activity/src/views/SetupView.tsx
@@ -4,15 +4,7 @@ import { HeaderBar } from '../components/HeaderBar';
 import { CharacterHeader } from '../components/CharacterHeader';
 import { Divider, PrimaryCTA } from '../components/ui';
 import { RoleEditor } from '../components/RoleEditor';
-import { getPrimaryRole, isPlayerReady } from '../lib/roles';
-
-const ROLE_COLOR_MAP: Record<string, string> = {
-  tank: 'var(--color-tank)',
-  healer: 'var(--color-healer)',
-  ranged: 'var(--color-dps)',
-  melee: 'var(--color-dps)',
-  unassigned: 'var(--text-secondary)',
-};
+import { getPrimaryRole, getRoleColor, isPlayerReady } from '../lib/roles';
 
 interface SetupViewProps {
   onNavigate: (view: 'identity' | 'lobby' | 'home', opts?: { replace?: boolean }) => void;
@@ -63,7 +55,7 @@ export function SetupView({ onNavigate }: SetupViewProps) {
   }
 
   const primaryRole = getPrimaryRole(player);
-  const color = ROLE_COLOR_MAP[primaryRole] ?? ROLE_COLOR_MAP.unassigned;
+  const color = getRoleColor(primaryRole);
   const ready = isPlayerReady(player);
 
   return (

--- a/packages/bot/src/services/issueTrackingService.ts
+++ b/packages/bot/src/services/issueTrackingService.ts
@@ -25,11 +25,4 @@ export class IssueTrackingService {
       createdAt: SERVER_TIMESTAMP,
     });
   }
-
-  async deleteTracking(issueNumber: number): Promise<void> {
-    if (!this.firebase.db) return;
-
-    const docRef = this.firebase.db.collection('issueTracking').doc(String(issueNumber));
-    await docRef.delete();
-  }
 }

--- a/packages/bot/tests/issueTrackingService.test.ts
+++ b/packages/bot/tests/issueTrackingService.test.ts
@@ -10,8 +10,7 @@ vi.mock('../src/core/firebaseService.js', () => ({
 
 describe('IssueTrackingService', () => {
   const mockSet = vi.fn().mockResolvedValue(undefined);
-  const mockDelete = vi.fn().mockResolvedValue(undefined);
-  const mockDoc = vi.fn().mockReturnValue({ set: mockSet, delete: mockDelete });
+  const mockDoc = vi.fn().mockReturnValue({ set: mockSet });
   const mockCollection = vi.fn().mockReturnValue({ doc: mockDoc });
 
   const mockFirebase = {
@@ -59,21 +58,4 @@ describe('IssueTrackingService', () => {
     });
   });
 
-  describe('deleteTracking', () => {
-    it('deletes the document from the issueTracking collection', async () => {
-      await service.deleteTracking(42);
-
-      expect(mockCollection).toHaveBeenCalledWith('issueTracking');
-      expect(mockDoc).toHaveBeenCalledWith('42');
-      expect(mockDelete).toHaveBeenCalled();
-    });
-
-    it('returns early when Firebase is unavailable', async () => {
-      const nullDbService = new IssueTrackingService({ db: null } as unknown as FirebaseService);
-
-      await nullDbService.deleteTracking(1);
-
-      expect(mockDelete).not.toHaveBeenCalled();
-    });
-  });
 });

--- a/packages/functions/src/affixMetadata.ts
+++ b/packages/functions/src/affixMetadata.ts
@@ -2,7 +2,6 @@
 export {
   STATIC_AFFIXES,
   BARGAIN_AFFIXES,
-  FORT_TYRAN_AFFIXES,
   resolveAffixDisplay,
 } from '@mythicplus/shared';
 

--- a/packages/shared/src/affixMetadata.ts
+++ b/packages/shared/src/affixMetadata.ts
@@ -28,8 +28,8 @@ export const BARGAIN_AFFIXES: Record<number, AffixDisplay> = {
   160: { id: 160, name: "Xal'atath's Bargain: Devour", nickname: 'Dispel Allies', keystoneLevel: '+4–11', wowheadUrl: 'https://www.wowhead.com/affix=160/xalataths-bargain-devour', color: '#a855f7' },
 };
 
-// Fort/Tyran
-export const FORT_TYRAN_AFFIXES: Record<number, AffixDisplay> = {
+// Fort/Tyran (internal — only consumed by resolveAffixDisplay)
+const FORT_TYRAN_AFFIXES: Record<number, AffixDisplay> = {
   10: { id: 10, name: 'Fortified', nickname: null, keystoneLevel: '+7', wowheadUrl: 'https://www.wowhead.com/affix=10/fortified', color: '#ef4444' },
   9: { id: 9, name: 'Tyrannical', nickname: null, keystoneLevel: '+7', wowheadUrl: 'https://www.wowhead.com/affix=9/tyrannical', color: '#ef4444' },
 };

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -28,7 +28,6 @@ export { getUtilitiesForClass, getRoleForSpec } from './classData.js';
 export {
   STATIC_AFFIXES,
   BARGAIN_AFFIXES,
-  FORT_TYRAN_AFFIXES,
   resolveAffixDisplay,
 } from './affixMetadata.js';
 


### PR DESCRIPTION
## Summary
- \`SetupView.tsx\` had a duplicate \`ROLE_COLOR_MAP\` constant; replaced with the existing \`getRoleColor()\` wrapper from \`lib/roles\`.
- \`FORT_TYRAN_AFFIXES\` was exported from shared/index and re-exported from functions/affixMetadata but never consumed outside the module that defines it. Made module-private.
- \`IssueTrackingService.deleteTracking\` had zero callers in production code; removed (and its tests).

## Test plan
- [x] \`./scripts/verify-ts.sh\` (231 tests pass — was 233 before; 2 deleteTracking tests removed)
- [x] \`npm -w activity run typecheck\`

🤖 Generated by /overnight run 20260427-063034