### PR TITLE
test(shared): cover resolveAffixDisplay + toCharacterClass

### DIFF
--- a/packages/bot/tests/affixMetadata.test.ts
+++ b/packages/bot/tests/affixMetadata.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { resolveAffixDisplay, STATIC_AFFIXES, BARGAIN_AFFIXES } from '@mythicplus/shared';
+
+describe('resolveAffixDisplay', () => {
+  it('returns the static affix entry for a known static ID', () => {
+    const lindormi = resolveAffixDisplay(165);
+    expect(lindormi).not.toBeNull();
+    expect(lindormi?.id).toBe(165);
+    expect(STATIC_AFFIXES.some((a) => a.id === 165)).toBe(true);
+  });
+
+  it('returns the static affix entry for the level-12 affix', () => {
+    const guile = resolveAffixDisplay(147);
+    expect(guile).not.toBeNull();
+    expect(guile?.id).toBe(147);
+  });
+
+  it('returns the bargain affix entry for a known bargain ID', () => {
+    for (const id of [148, 158, 162, 160]) {
+      const found = resolveAffixDisplay(id);
+      expect(found, `missing bargain id ${id}`).not.toBeNull();
+      expect(found?.id).toBe(id);
+      expect(BARGAIN_AFFIXES[id]).toBeDefined();
+    }
+  });
+
+  it('returns the fort/tyran entries for IDs 9 and 10', () => {
+    expect(resolveAffixDisplay(10)?.name).toBe('Fortified');
+    expect(resolveAffixDisplay(9)?.name).toBe('Tyrannical');
+  });
+
+  it('returns null for unknown IDs', () => {
+    expect(resolveAffixDisplay(0)).toBeNull();
+    expect(resolveAffixDisplay(9999)).toBeNull();
+    expect(resolveAffixDisplay(-1)).toBeNull();
+  });
+});

--- a/packages/bot/tests/types.test.ts
+++ b/packages/bot/tests/types.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { toCharacterClass, CHARACTER_CLASSES } from '@mythicplus/shared';
+
+describe('toCharacterClass', () => {
+  it('returns the input verbatim for every valid class name', () => {
+    for (const cls of CHARACTER_CLASSES) {
+      expect(toCharacterClass(cls)).toBe(cls);
+    }
+  });
+
+  it('returns null for an unknown class name', () => {
+    expect(toCharacterClass('FakeClass')).toBeNull();
+    expect(toCharacterClass('druid')).toBeNull(); // case-sensitive
+    expect(toCharacterClass('')).toBeNull();
+  });
+
+  it('returns null for non-string inputs', () => {
+    expect(toCharacterClass(undefined)).toBeNull();
+    expect(toCharacterClass(null)).toBeNull();
+    expect(toCharacterClass(42)).toBeNull();
+    expect(toCharacterClass({})).toBeNull();
+    expect(toCharacterClass(['Druid'])).toBeNull();
+    expect(toCharacterClass(true)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Both shared validators were untested. Adding direct tests so a regression in either surfaces in CI rather than at runtime.

- **\`resolveAffixDisplay\`** (\`packages/shared/src/affixMetadata.ts\`) — covers all three lookup tables (STATIC, BARGAIN, FORT_TYRAN) and the unknown-ID null-return branch. A bug here silently displays the wrong affix in the wheel UI.
- **\`toCharacterClass\`** (\`packages/shared/src/types.ts\`) — covers every valid class name, case-sensitivity, and the null-returning branches (non-string and unknown-string inputs). A bug here silently drops the class on Firestore deserialization, breaking class-colored wheel slots.

## Test plan
- [x] \`npm -w packages/bot run test\` — 8 new tests, 241 total pass

🤖 Generated by /overnight run 20260427-063034