### PR TITLE
refactor(functions): use firebase-functions logger instead of console.*

### DIFF
--- a/packages/functions/src/githubWebhook.ts
+++ b/packages/functions/src/githubWebhook.ts
@@ -2,6 +2,7 @@ import { createHmac, timingSafeEqual } from 'node:crypto';
 import { onRequest } from 'firebase-functions/v2/https';
 import { getFirestore } from 'firebase-admin/firestore';
 import { defineSecret } from 'firebase-functions/params';
+import { logger } from 'firebase-functions';
 
 const discordBotToken = defineSecret('BOT_TOKEN');
 const githubWebhookSecret = defineSecret('GITHUB_WEBHOOK_SECRET');
@@ -91,7 +92,7 @@ export async function handleIssueWebhook(
       `Your issue "${data.issueTitle}" has been resolved!\n${data.issueUrl}`,
     );
   } catch (e) {
-    console.warn(`Failed to DM user ${data.discordUserId}: ${e}`);
+    logger.warn(`Failed to DM user ${data.discordUserId}`, e);
   }
 
   await docRef.delete();

--- a/packages/functions/src/refreshCharacterMedia.ts
+++ b/packages/functions/src/refreshCharacterMedia.ts
@@ -1,5 +1,6 @@
 import { onSchedule } from 'firebase-functions/v2/scheduler';
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import { logger } from 'firebase-functions';
 import { getFirestore, FieldValue, type Firestore } from 'firebase-admin/firestore';
 import { getBattleNetClient, type BattleNetClient } from './battlenet.js';
 import { buildCharacterResult, type CharacterResult } from './lookupCharacter.js';
@@ -158,7 +159,7 @@ export async function runRefresh(): Promise<RefreshSummary> {
       summary.cleared += 1;
     } catch (err) {
       summary.failed += 1;
-      console.warn(`[refreshCharacterMedia] ${discordId} clear failed:`, err);
+      logger.warn(`[refreshCharacterMedia] ${discordId} clear failed`, err);
     }
   }
 
@@ -206,11 +207,11 @@ export async function runRefresh(): Promise<RefreshSummary> {
       summary.refreshed += 1;
     } catch (err) {
       summary.failed += 1;
-      console.warn(`[refreshCharacterMedia] ${target.discordId} (${target.linkedCharacter.name}-${target.linkedCharacter.realm}) failed:`, err);
+      logger.warn(`[refreshCharacterMedia] ${target.discordId} (${target.linkedCharacter.name}-${target.linkedCharacter.realm}) failed`, err);
     }
   }
 
-  console.log(`[refreshCharacterMedia] ${JSON.stringify(summary)}`);
+  logger.info('[refreshCharacterMedia] summary', summary);
   return summary;
 }
 


### PR DESCRIPTION
## Summary
Cloud Functions route \`console.*\` output to Cloud Logging but lose structured metadata (severity, labels). The official \`logger\` from \`firebase-functions\` adds those automatically and is already a transitive dep.

Replaces 4 \`console.*\` call sites in \`refreshCharacterMedia.ts\` and \`githubWebhook.ts\`. Same level mapping: \`warn → logger.warn\`, \`log → logger.info\`.

## Test plan
- [x] \`npm run lint\` passes
- [x] \`npx -w packages/functions tsc --noEmit\` passes

🤖 Generated by /overnight run 20260427-063034