### PR TITLE
refactor(activity): route identity-hook errors through reportError()

### DIFF
--- a/activity/src/hooks/useIdentity.ts
+++ b/activity/src/hooks/useIdentity.ts
@@ -4,6 +4,7 @@ import { getParticipants } from '../discordSdk';
 import { WoWPlayer } from '../types';
 import { firestoreService } from '../services/firestoreService';
 import { demoService } from '../services/demoService';
+import { reportError } from '../lib/sentry';
 
 function getSessionService() {
   return useAppStore.getState().isDemoMode ? demoService : firestoreService;
@@ -36,7 +37,9 @@ function commitIdentity(player: WoWPlayer, guildId: string | null, opts: CommitO
   if (opts.persist) {
     localStorage.setItem(getIdentityStorageKey(guildId), player.discordId);
   }
-  getSessionService().claimPlayer(player.discordId).catch(console.error);
+  getSessionService().claimPlayer(player.discordId).catch((err) => {
+    reportError(err, { tag: 'useIdentity.claimPlayer' });
+  });
 }
 
 export function useIdentity() {
@@ -104,7 +107,9 @@ export function useIdentity() {
     localStorage.removeItem(getIdentityStorageKey(guildId));
     state.resetIdentity();
     if (previousId) {
-      getSessionService().unclaimPlayer(previousId).catch(console.error);
+      getSessionService().unclaimPlayer(previousId).catch((err) => {
+        reportError(err, { tag: 'useIdentity.unclaimPlayer' });
+      });
     }
   }, []);
 

--- a/activity/src/hooks/useIdentityResolver.ts
+++ b/activity/src/hooks/useIdentityResolver.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { useIdentity } from './useIdentity';
 import { WoWPlayer } from '../types';
+import { reportError } from '../lib/sentry';
 
 /**
  * Automatically resolves the current user's identity when players change.
@@ -27,7 +28,9 @@ export function useIdentityResolver(players: WoWPlayer[]) {
   const { resolveIdentity } = identity;
   useEffect(() => {
     if (playersRef.current.length > 0) {
-      resolveIdentity(playersRef.current).catch(console.error);
+      resolveIdentity(playersRef.current).catch((err) => {
+        reportError(err, { tag: 'useIdentityResolver.resolveIdentity' });
+      });
     }
   }, [membershipKey, resolveIdentity]);
 


### PR DESCRIPTION
## Summary
Three hook call sites still used \`.catch(console.error)\` and bypassed Sentry:
- \`useIdentity.claimPlayer\`
- \`useIdentity.unclaimPlayer\`
- \`useIdentityResolver.resolveIdentity\`

Switched to the existing \`reportError(err, { tag })\` wrapper so identity-flow failures get tagged Sentry events instead of disappearing into the console.

## Test plan
- [x] \`npm -w activity run typecheck\` passes

🤖 Generated by /overnight run 20260427-063034