### PR TITLE
refactor(bot): centralize error capture in reportError() helper

### DIFF
--- a/packages/bot/src/core/sentry.ts
+++ b/packages/bot/src/core/sentry.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/node';
+import logger from './logger.js';
 import { SENTRY_DSN, GIT_SHA } from './config.js';
 
 export function initSentry() {
@@ -10,6 +11,23 @@ export function initSentry() {
     environment: process.env.NODE_ENV ?? 'production',
     tracesSampleRate: 0.1,
   });
+}
+
+export interface ReportErrorContext {
+  tags?: Record<string, string | undefined>;
+  user?: { id: string; username: string };
+  extra?: Record<string, unknown>;
+}
+
+/**
+ * Log an error to winston and forward it to Sentry with optional context.
+ * Mirrors the activity frontend's `reportError(err, { tag })` wrapper so
+ * both surfaces share a single error-reporting entrypoint.
+ */
+export function reportError(err: unknown, context?: ReportErrorContext): void {
+  const handler = context?.tags?.handler;
+  logger.error(handler ? `[${handler}] ${err}` : `${err}`);
+  Sentry.captureException(err, context);
 }
 
 export { Sentry };

--- a/packages/bot/src/main.ts
+++ b/packages/bot/src/main.ts
@@ -1,4 +1,4 @@
-import { initSentry, Sentry } from './core/sentry.js';
+import { initSentry, reportError, Sentry } from './core/sentry.js';
 initSentry();
 
 import {
@@ -605,9 +605,9 @@ async function main() {
         await handleModalSubmit(interaction);
       }
     } catch (e) {
-      logger.error(`Interaction error: ${e}`);
-      Sentry.captureException(e, {
+      reportError(e, {
         tags: {
+          handler: 'interaction',
           command: interaction.isChatInputCommand() ? interaction.commandName : 'button',
           guild: interaction.guildId ?? 'DM',
         },
@@ -1242,8 +1242,7 @@ async function main() {
         after,
       );
     } catch (e) {
-      logger.error(`Voice state update error: ${e}`);
-      Sentry.captureException(e, { tags: { handler: 'voiceStateUpdate' } });
+      reportError(e, { tags: { handler: 'voiceStateUpdate' } });
     }
   });
 
@@ -1288,8 +1287,7 @@ function adaptVoiceChannelForCtx(ch: import('discord.js').VoiceChannel) {
 
 // -- Start --
 main().catch(async (e) => {
-  logger.error(`Fatal: ${e}`);
-  Sentry.captureException(e, { tags: { handler: 'fatal' } });
+  reportError(e, { tags: { handler: 'fatal' } });
   await Sentry.flush(2000);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
Mirrors the activity frontend's \`reportError(err, { tag })\` wrapper. Bot had three raw \`Sentry.captureException\` call sites in \`main.ts\`, each separately calling \`logger.error\`. The helper now does both.

- Adds \`reportError(err, context)\` to \`packages/bot/src/core/sentry.ts\` (context covers \`tags\` + \`user\` + \`extra\`).
- Replaces all three call sites in \`main.ts\` (interaction handler, voiceStateUpdate, fatal).
- Fatal path still calls \`Sentry.flush()\` directly before \`process.exit\` — \`reportError\` isn't a full drop-in for that case.

## Test plan
- [x] \`./scripts/verify-ts.sh\` passes (lint + typecheck + 241 tests)

🤖 Generated by /overnight run 20260427-063034