### PR TITLE
refactor(shared): extract todayPST() helper

### DIFF
--- a/activity/src/services/firestoreService.ts
+++ b/activity/src/services/firestoreService.ts
@@ -3,7 +3,7 @@ import { db } from '../firebase';
 import { GuildData, ChannelData } from '../types';
 import { useAppStore } from '../store/store';
 import type { SessionService } from './types';
-import { WoWPlayer, WoWGroup, createMythicPlusGroups, setGroupHistory } from '@mythicplus/shared';
+import { WoWPlayer, WoWGroup, createMythicPlusGroups, setGroupHistory, todayPST } from '@mythicplus/shared';
 import type { CharacterClass } from '@mythicplus/shared';
 import { reportError } from '../lib/sentry';
 
@@ -163,7 +163,7 @@ class FirestoreSessionService implements SessionService {
     if (!currentChannelId || !channelData) return;
 
     const guildId = channelData.guildId || null;
-    const today = new Date().toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' });
+    const today = todayPST();
 
     // Restore group history from Firestore so the algorithm avoids repeat
     // groupings. Malformed history should never block a spin — fall back to

--- a/packages/bot/src/services/groupService.ts
+++ b/packages/bot/src/services/groupService.ts
@@ -1,4 +1,4 @@
-import { WoWGroup, WoWPlayer, createMythicPlusGroups, setGroupHistory } from '@mythicplus/shared';
+import { WoWGroup, WoWPlayer, createMythicPlusGroups, setGroupHistory, todayPST } from '@mythicplus/shared';
 import { announceGroup, type Sendable } from '../core/groupUi.js';
 import { getDebugPlayers, getPlayerList, type DiscordMember, type TypingChannel } from '../core/utils.js';
 import { FirebaseService } from '../core/firebaseService.js';
@@ -61,7 +61,7 @@ export class GroupService {
 
     try {
       const history = await firebase.getGroupHistory(guildId);
-      if (!history || history.date !== new Date().toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' })) {
+      if (!history || history.date !== todayPST()) {
         this.loadedRounds.set(guildId, []);
         setGroupHistory([], guildId);
         return;
@@ -87,7 +87,7 @@ export class GroupService {
     try {
       const existingRounds = this.loadedRounds.get(guildId) ?? [];
       const newRound = groups.map((g) => g.toDict() as Record<string, unknown>);
-      const today = new Date().toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' });
+      const today = todayPST();
       await firebase.saveGroupHistory(guildId, {
         date: today,
         rounds: [...existingRounds, newRound],

--- a/packages/shared/src/dateHelpers.ts
+++ b/packages/shared/src/dateHelpers.ts
@@ -1,0 +1,12 @@
+/**
+ * Returns today's date as an ISO `YYYY-MM-DD` string in the America/Los_Angeles
+ * timezone. Used as the rotation key for daily group history so the bot and
+ * frontend agree on "today" regardless of the runtime locale.
+ *
+ * The PST/PDT pin matches Tyler's home timezone — group history is meant to
+ * roll over at midnight Pacific, not midnight UTC or wherever the bot
+ * happens to be deployed.
+ */
+export function todayPST(): string {
+  return new Date().toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' });
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -42,3 +42,5 @@ export type {
 } from './types.js';
 
 export { CHARACTER_CLASSES, toCharacterClass } from './types.js';
+
+export { todayPST } from './dateHelpers.js';


### PR DESCRIPTION
## Summary
The PST date expression \`new Date().toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' })\` was duplicated 3× across \`groupService.ts\` (twice) and \`firestoreService.ts\` (once). Centralizes it in \`packages/shared/src/dateHelpers.ts\` so a future timezone or locale change happens in one place.

No behavior change.

## Test plan
- [x] \`./scripts/verify-ts.sh\` passes
- [x] \`npm -w activity run typecheck\` passes

🤖 Generated by /overnight run 20260427-063034