### PR TITLE
refactor(session): add registerChannel() to encapsulate active-tracking writes

### DIFF
--- a/packages/bot/src/main.ts
+++ b/packages/bot/src/main.ts
@@ -566,13 +566,7 @@ async function main() {
         });
 
         // Register the channel as active so voice state changes are tracked.
-        if (!sessionService.activeChannels.has(channelId)) {
-          sessionService.activeChannels.set(channelId, {
-            docId: channelId,
-            guildId,
-          });
-          sessionService.activeGuilds.add(guildId);
-        }
+        sessionService.registerChannel(channelId, guildId, channelId);
 
         logger.debug(`Refreshed players for channel ${channelId} (${playersData.length} players)`);
       } catch (e) {

--- a/packages/bot/src/services/sessionService.ts
+++ b/packages/bot/src/services/sessionService.ts
@@ -40,6 +40,17 @@ export class SessionService {
     this.firebase = firebase ?? FirebaseService.getInstance();
   }
 
+  /**
+   * Mark a channel as active and its guild as having an active session.
+   * Idempotent — re-registering an already-active channel is a no-op
+   * regardless of which side calls it (refresh listener, command handler).
+   */
+  registerChannel(channelId: string, guildId: string, docId: string): void {
+    if (this.activeChannels.has(channelId)) return;
+    this.activeChannels.set(channelId, { docId, guildId });
+    this.activeGuilds.add(guildId);
+  }
+
   shutdown(): void {
     for (const watch of this.channelListeners.values()) {
       watch?.unsubscribe();


### PR DESCRIPTION
## Summary
The channel-refresh listener in \`main.ts\` directly mutated SessionService internals (\`activeChannels.set\` + \`activeGuilds.add\`), bypassing the service's invariant that any guild in \`activeGuilds\` must own at least one channel in \`activeChannels\`.

Adds an idempotent \`registerChannel(channelId, guildId, docId)\` method and uses it from \`main.ts\`. Maps stay public for now — there are still read sites (\`.has\`, \`.get\`) that haven't been migrated.

## Test plan
- [x] \`./scripts/verify-ts.sh\` passes (lint + typecheck + 247 tests)

🤖 Generated by /overnight run 20260427-063034