### PR TITLE
perf(shared): avoid players-getter allocation in WoWGroup hot getters

### DIFF
--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -284,16 +284,25 @@ export class WoWGroup {
     this.dps = dps;
   }
 
+  // Avoid the `players` getter's intermediate array allocation in the hot
+  // path — the algorithm calls these getters once per group per fill phase,
+  // so allocating a fresh array per call would be O(groups * phases) per spin.
   get hasBrez(): boolean {
-    return this.players.some((p) => p.hasBrez);
+    return (this.tank?.hasBrez ?? false)
+      || (this.healer?.hasBrez ?? false)
+      || this.dps.some((p) => p.hasBrez);
   }
 
   get hasLust(): boolean {
-    return this.players.some((p) => p.hasLust);
+    return (this.tank?.hasLust ?? false)
+      || (this.healer?.hasLust ?? false)
+      || this.dps.some((p) => p.hasLust);
   }
 
   get hasRanged(): boolean {
-    return this.players.some((p) => p.ranged);
+    return (this.tank?.ranged ?? false)
+      || (this.healer?.ranged ?? false)
+      || this.dps.some((p) => p.ranged);
   }
 
   get isComplete(): boolean {
@@ -301,7 +310,7 @@ export class WoWGroup {
   }
 
   get size(): number {
-    return this.players.length;
+    return (this.tank ? 1 : 0) + (this.healer ? 1 : 0) + this.dps.length;
   }
 
   get players(): WoWPlayer[] {


### PR DESCRIPTION
## Summary
\`WoWGroup.hasBrez\` / \`hasLust\` / \`hasRanged\` / \`size\` all went through the \`players\` getter, which allocates a fresh \`[tank, healer, ...dps]\` array on every call. The group-creation algorithm calls these once per group per fill phase, so a 4-group spin throws away ~12+ short-lived arrays just to read four booleans.

Replaces with direct \`tank?.x ?? false || healer?.x ?? false || dps.some(...)\` checks. Same behavior, no allocations.

## Test plan
- [x] \`./scripts/verify-ts.sh\` passes — \`WoWGroup\` round-trip and utility-detection tests all green

🤖 Generated by /overnight run 20260427-063034