### PR TITLE
refactor(activity): extract eligibleSpinPlayers helper

### DIFF
--- a/activity/src/lib/spinEligibility.ts
+++ b/activity/src/lib/spinEligibility.ts
@@ -1,0 +1,27 @@
+import type { WoWPlayerDict } from '@mythicplus/shared';
+import { WoWPlayer } from '@mythicplus/shared';
+
+/**
+ * Filter the channel's players down to those eligible to spin: must have at
+ * least one role declared and must not appear in `sittingOut`.
+ *
+ * Lives here (not in `@mythicplus/shared`) because both call sites are in
+ * the activity frontend and the shared package shouldn't depend on the
+ * frontend's `WoWPlayerDict` shape contract beyond what's already exported.
+ *
+ * Both `firestoreService.requestSpin` and `demoService.requestSpin` use this
+ * — keeping a single helper means demo and prod can never diverge on what
+ * "eligible" means.
+ */
+export function eligibleSpinPlayers(
+  players: WoWPlayerDict[],
+  sittingOut: readonly string[],
+): WoWPlayer[] {
+  return players
+    .filter(
+      (p) =>
+        (p.mainRole !== null || p.offspecs.length > 0) &&
+        (!p.discordId || !sittingOut.includes(p.discordId)),
+    )
+    .map((p) => WoWPlayer.fromDict(p));
+}

--- a/activity/src/services/demoService.ts
+++ b/activity/src/services/demoService.ts
@@ -2,8 +2,9 @@ import { mockChannelData, mockPlayers, mockGuildData } from '../lib/mockData';
 import { useAppStore } from '../store/store';
 import type { SessionService } from './types';
 import type { ChannelData } from '../types';
-import { WoWPlayer, createMythicPlusGroups } from '@mythicplus/shared';
+import { createMythicPlusGroups } from '@mythicplus/shared';
 import type { CharacterClass } from '@mythicplus/shared';
+import { eligibleSpinPlayers } from '../lib/spinEligibility';
 
 /**
  * Apply a partial update to the in-memory channelData. No-op when there is
@@ -32,11 +33,7 @@ class DemoSessionService implements SessionService {
     const currentData = useAppStore.getState().channelData;
     if (!currentData) return;
 
-    const sittingOut = currentData.sittingOut ?? [];
-    const players = currentData.players
-      .filter((p) => (p.mainRole !== null || p.offspecs.length > 0)
-        && (!p.discordId || !sittingOut.includes(p.discordId)))
-      .map((p) => WoWPlayer.fromDict(p));
+    const players = eligibleSpinPlayers(currentData.players, currentData.sittingOut ?? []);
 
     const groupDicts = createMythicPlusGroups(players, true, null).map((g) => g.toDict());
 

--- a/activity/src/services/firestoreService.ts
+++ b/activity/src/services/firestoreService.ts
@@ -3,9 +3,10 @@ import { db } from '../firebase';
 import { GuildData, ChannelData } from '../types';
 import { useAppStore } from '../store/store';
 import type { SessionService } from './types';
-import { WoWPlayer, WoWGroup, createMythicPlusGroups, setGroupHistory, todayPST } from '@mythicplus/shared';
+import { WoWGroup, createMythicPlusGroups, setGroupHistory, todayPST } from '@mythicplus/shared';
 import type { CharacterClass } from '@mythicplus/shared';
 import { reportError } from '../lib/sentry';
+import { eligibleSpinPlayers } from '../lib/spinEligibility';
 
 const MAX_LISTENER_RETRIES = 5;
 const NON_RECOVERABLE_CODES = new Set(['permission-denied', 'not-found', 'unauthenticated']);
@@ -179,11 +180,7 @@ class FirestoreSessionService implements SessionService {
       setGroupHistory([], guildId);
     }
 
-    const sittingOut = channelData.sittingOut ?? [];
-    const players = channelData.players
-      .filter(p => (p.mainRole !== null || p.offspecs.length > 0)
-        && (!p.discordId || !sittingOut.includes(p.discordId)))
-      .map(p => WoWPlayer.fromDict(p));
+    const players = eligibleSpinPlayers(channelData.players, channelData.sittingOut ?? []);
 
     const groups = createMythicPlusGroups(players, true, guildId);
     const groupDicts = groups.map(g => g.toDict());


### PR DESCRIPTION
## Summary
The eligibility filter (has a role + not sitting out) was duplicated verbatim in \`firestoreService.requestSpin\` and \`demoService.requestSpin\`. Extracted to \`activity/src/lib/spinEligibility.ts\` so demo can never silently diverge from prod.

No behavior change.

## Test plan
- [x] \`npm -w activity run typecheck\` passes

🤖 Generated by /overnight run 20260427-063034