### PR TITLE
chore: drop unused exports across bot/activity

### DIFF
--- a/activity/src/components/WheelsGrid.tsx
+++ b/activity/src/components/WheelsGrid.tsx
@@ -50,9 +50,6 @@ export interface WheelsGridRef {
   grid: WheelsGridHandle | null;
 }
 
-// Re-export under the old class-alias name so existing callers keep working.
-export type { WheelsGridHandle as WheelsGridClass };
-
 interface DotConfig {
   ariaLabel: string;
   dotColor: string;

--- a/activity/src/discordSdk.ts
+++ b/activity/src/discordSdk.ts
@@ -53,8 +53,6 @@ if (_isEmbedded) {
   patchUrlMappings(mappings);
 }
 
-export const isEmbedded = _isEmbedded;
-
 /**
  * Rewrite an external image URL to go through Discord's activity proxy.
  * Must be used for <img> src attributes since patchUrlMappings only patches fetch/XHR.

--- a/packages/bot/src/core/config.ts
+++ b/packages/bot/src/core/config.ts
@@ -1,21 +1,6 @@
 import 'dotenv/config';
 import { z } from 'zod';
 
-// Re-export shared role constants
-export {
-  ROLE_TANK,
-  ROLE_HEALER,
-  ROLE_RANGED,
-  ROLE_MELEE,
-  ROLE_TANK_OFFSPEC,
-  ROLE_HEALER_OFFSPEC,
-  ROLE_RANGED_OFFSPEC,
-  ROLE_MELEE_OFFSPEC,
-  ROLE_BREZ,
-  ROLE_LUST,
-  ALL_ROLES,
-} from '@mythicplus/shared';
-
 const envSchema = z.object({
   BOT_TOKEN: z.string().optional(),
   DISCORD_APPLICATION_ID: z.string().optional(),

--- a/packages/bot/src/core/groupUi.ts
+++ b/packages/bot/src/core/groupUi.ts
@@ -2,7 +2,7 @@ import { generateInviteCommand, type WoWGroup } from '@mythicplus/shared';
 import { PLACEHOLDER_CHAR } from './config.js';
 import { getMaskedName, showShortTyping } from './utils.js';
 
-export interface EmbedField {
+interface EmbedField {
   name: string;
   value: string;
   inline?: boolean;
@@ -30,7 +30,7 @@ function setFieldAt(embed: Embed, index: number, name: string, value: string): E
   return embed;
 }
 
-export interface GroupDisplayNames {
+interface GroupDisplayNames {
   tankName: string;
   healerName: string;
   dps1Name: string;
@@ -47,7 +47,7 @@ export interface GroupDisplayNames {
  * @param {WoWGroup} group - The generated group to extract names from.
  * @returns {GroupDisplayNames} A structured object containing formatted player names for UI display.
  */
-export function getGroupDisplayNames(group: WoWGroup): GroupDisplayNames {
+function getGroupDisplayNames(group: WoWGroup): GroupDisplayNames {
   const allPlayers = group.players;
   return {
     tankName: group.tank?.name ?? PLACEHOLDER_CHAR,
@@ -67,7 +67,7 @@ export function getGroupDisplayNames(group: WoWGroup): GroupDisplayNames {
  * @param {WoWGroup} group - The group to generate the invite command for.
  * @returns {EmbedField | null} The formatted EmbedField, or null if generation fails.
  */
-export function getInviteCommandField(group: WoWGroup): EmbedField | null {
+function getInviteCommandField(group: WoWGroup): EmbedField | null {
   const inviteCmd = generateInviteCommand(group.toDict());
   if (!inviteCmd) return null;
   const formatted = inviteCmd.includes('\n')
@@ -123,7 +123,7 @@ async function animateUpdate(
  * @param {boolean} debug - If true, skips artificial delays.
  * @returns {Promise<void>} Resolves when the entire animation sequence is complete.
  */
-export async function announceGroupAnimated(
+async function announceGroupAnimated(
   ctx: Sendable,
   channel: TypingChannel,
   group: WoWGroup,

--- a/packages/bot/src/core/preferenceService.ts
+++ b/packages/bot/src/core/preferenceService.ts
@@ -32,11 +32,6 @@ export function getPreferenceService(): PreferenceService {
   return _instance;
 }
 
-/** Reset singleton — for testing only. */
-export function _resetInstance(): void {
-  _instance = null;
-}
-
 export class PreferenceService implements IPreferenceService {
   firebase: FirebaseService;
   private _cache: Record<string, string[]> = {};

--- a/packages/bot/src/core/roleUi.ts
+++ b/packages/bot/src/core/roleUi.ts
@@ -9,7 +9,7 @@ import {
   ROLE_RANGED_OFFSPEC,
   ROLE_TANK,
   ROLE_TANK_OFFSPEC,
-} from './config.js';
+} from '@mythicplus/shared';
 
 export type ButtonStyle = 'primary' | 'secondary' | 'success';
 

--- a/packages/bot/src/core/utils.ts
+++ b/packages/bot/src/core/utils.ts
@@ -1,4 +1,3 @@
-import { WoWPlayer } from '@mythicplus/shared';
 import {
   ROLE_BREZ,
   ROLE_HEALER,
@@ -9,7 +8,8 @@ import {
   ROLE_RANGED,
   ROLE_TANK,
   ROLE_TANK_OFFSPEC,
-} from './config.js';
+  WoWPlayer,
+} from '@mythicplus/shared';
 import { getPreferenceService } from './preferenceService.js';
 
 export interface DiscordMember {


### PR DESCRIPTION
## Summary
- Dropped unused exports verified by the dead-code critic — none had any importer.
- Files: groupUi.ts internal helpers; config.ts role re-exports; discordSdk.ts isEmbedded; WheelsGrid.tsx WheelsGridClass alias; preferenceService.ts _resetInstance.

## Test plan
- [x] npm run lint
- [x] backend typecheck (shared + bot)
- [x] activity typecheck + build
- [x] vitest packages/bot

Generated by /overnight run 20260427-162857.