### PR TITLE
refactor(bot): dedupe TypingChannel interface

### DIFF
--- a/packages/bot/src/core/groupUi.ts
+++ b/packages/bot/src/core/groupUi.ts
@@ -1,6 +1,6 @@
 import { generateInviteCommand, type WoWGroup } from '@mythicplus/shared';
 import { PLACEHOLDER_CHAR } from './config.js';
-import { getMaskedName, showShortTyping } from './utils.js';
+import { getMaskedName, showShortTyping, type TypingChannel } from './utils.js';
 
 interface EmbedField {
   name: string;
@@ -93,10 +93,6 @@ export function buildGroupEmbed(group: WoWGroup, groupNumber: number): Embed {
   }
 
   return { title: `Group ${groupNumber}`, color: GOLD, fields };
-}
-
-interface TypingChannel {
-  sendTyping(): Promise<void>;
 }
 
 async function animateUpdate(


### PR DESCRIPTION
## Summary
- Removes the duplicated local `TypingChannel` interface declaration in `packages/bot/src/core/groupUi.ts` and imports the existing exported type from `./utils.js` instead.

## Test plan
- [x] `npm run lint`
- [x] `npm -w packages/shared run typecheck && npm -w packages/bot run typecheck`
- [x] `npm -w packages/bot run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)