### PR TITLE
docs: drop stale Prettier claim from CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Or use the npm script:
 npm run verify
 ```
 
--   **Linting/Formatting**: Uses `eslint` and `prettier` (or built-in formatters).
+-   **Linting/Formatting**: Uses `eslint` (the project has no Prettier config — `eslint` is the only formatter/linter).
 -   **Type Checking**: Uses `tsc --noEmit`.
 -   **Tests**: Runs tests via `vitest`.
 


### PR DESCRIPTION
## Summary
- Fix a stale claim in `CONTRIBUTING.md` Verification section: it asserted the project uses both `eslint` and `prettier`, but there is no Prettier config or dependency anywhere in the repo.
- Update the bullet to reflect reality: `eslint` is the only formatter/linter.

## Test plan
- [x] `git diff` shows only `CONTRIBUTING.md` changed (1 line).
- [x] No code paths affected — markdown-only doc fix.

Found by overnight docs critic (T04).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

Generated with Claude Code