### PR TITLE
docs: rename stale snake_case identifiers in ARCHITECTURE

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -215,7 +215,7 @@ sequenceDiagram
 
     User->>Discord: /activity (in voice channel)
     Discord->>Bot: command
-    Bot->>Bot: GroupService.get_groups_data (players from channel)
+    Bot->>Bot: GroupService.getGroupsData (players from channel)
     Bot->>Firestore: create session (lobby, players)
     Firestore-->>Bot: sessionId
     Bot->>Discord: reply with Activity link + browser link (sessionId)
@@ -224,8 +224,8 @@ sequenceDiagram
 
     loop Lobby
         User->>Discord: join/leave voice
-        Discord->>Bot: on_voice_state_update
-        Bot->>Firestore: update_session(players)
+        Discord->>Bot: onVoiceStateUpdate
+        Bot->>Firestore: updateChannelPlayers(players)
         Firestore-->>Frontend: snapshot → update lobby
     end
 


### PR DESCRIPTION
## Summary

Fixes pre-port Python-style snake_case method names in `ARCHITECTURE.md` that were never updated when the bot was rewritten in TypeScript. The sequence diagram for "How an Activity Run Works" referenced symbols that don't exist in the current codebase.

## Renames

All edits in the Mermaid sequence diagram block:

| Stale (Python-style) | Actual TypeScript symbol | Source |
| --- | --- | --- |
| `GroupService.get_groups_data` | `GroupService.getGroupsData` | `packages/bot/src/services/groupService.ts:102` |
| `on_voice_state_update` | `onVoiceStateUpdate` | `packages/bot/src/events/voiceStateUpdate.ts:14` |
| `update_session(players)` | `updateChannelPlayers(players)` | `packages/bot/src/services/sessionService.ts:115` |

Other snake_case strings in the file were verified to be legitimate and were left alone:
- `player_preferences.json` — actual filename (see `packages/bot/src/core/storage.ts:10-11`)
- `<issue_number>` — placeholder for a GitHub issue number in a Firestore doc path

## Test plan

- [x] `git diff ARCHITECTURE.md` confirms only the three intended renames
- [x] No code files touched