### PR TITLE
docs: add Firebase env-var section to ACTIVITY_SETUP

### DIFF
--- a/ACTIVITY_SETUP.md
+++ b/ACTIVITY_SETUP.md
@@ -32,6 +32,41 @@ We have added a GitHub Action to automatically deploy your activity files. You j
     *   **Target**: Paste the GitHub Pages URL you copied earlier (e.g., `https://yourname.github.io/your-repo/`).
     *   *Important:* Ensure the target URL matches exactly.
 
+## 2.5 Firebase Configuration
+
+The activity uses Firebase (Firestore + Auth + Functions) for real-time lobby
+state and group reveals. Without these credentials the frontend will fail to
+initialize and the bot cannot persist sessions.
+
+### Frontend (`activity/`)
+
+The Vite frontend reads the following variables at **build time** (Vite inlines
+`import.meta.env.VITE_*` into the bundle), so they must be present whenever the
+activity is built — including in CI when the GitHub Pages workflow runs. Add
+each one as a **repository secret** in GitHub (`Settings` → `Secrets and
+variables` → `Actions`) so the deploy workflow can pass them through:
+
+| Variable                            | Source (Firebase Console → Project Settings) |
+| ----------------------------------- | -------------------------------------------- |
+| `VITE_FIREBASE_API_KEY`             | Web app config — `apiKey`                    |
+| `VITE_FIREBASE_AUTH_DOMAIN`         | Web app config — `authDomain`                |
+| `VITE_FIREBASE_PROJECT_ID`          | Web app config — `projectId`                 |
+| `VITE_FIREBASE_STORAGE_BUCKET`      | Web app config — `storageBucket`             |
+| `VITE_FIREBASE_MESSAGING_SENDER_ID` | Web app config — `messagingSenderId`         |
+| `VITE_FIREBASE_APP_ID`              | Web app config — `appId`                     |
+
+For local development, place the same values in `activity/.env.local`.
+
+### Bot
+
+The bot writes session state to Firestore using a service account. Set
+`FIREBASE_CREDENTIALS_JSON` in the bot's environment to the full JSON of a
+Firebase Admin SDK service account key.
+
+See [FIREBASE_SETUP.md](FIREBASE_SETUP.md) for instructions on provisioning the
+Firebase project, enabling Firestore, and generating both the web app config
+and the service account credentials.
+
 ## 3. Running the Activity
 
 1.  Start your bot.


### PR DESCRIPTION
## Summary

`ACTIVITY_SETUP.md` walked through Discord Developer Portal config and how to deploy to GitHub Pages, but never told the user that the activity needs Firebase credentials at compile time. Without them the frontend silently fails to initialize and the bot cannot persist sessions.

This PR adds a new **2.5 Firebase Configuration** section between the Developer Portal config and "Running the Activity" steps, covering:

- The six `VITE_FIREBASE_*` build-time variables the frontend reads from `activity/src/firebase.ts` (apiKey, authDomain, projectId, storageBucket, messagingSenderId, appId), each mapped to its source in the Firebase Console web app config.
- A note that these must be added as **GitHub repository secrets** because Vite inlines `import.meta.env.VITE_*` at build time, so the GitHub Pages deploy workflow needs them.
- The bot-side `FIREBASE_CREDENTIALS_JSON` requirement.
- A cross-link to `FIREBASE_SETUP.md` for the underlying project provisioning.

Resolves T07 from the docs-critic overnight run.

## Test plan

- [x] Verified the variable list against `activity/src/firebase.ts` (no `MEASUREMENT_ID` — the code only references the six listed)
- [x] `git diff` confirms only `ACTIVITY_SETUP.md` changed
- [ ] Reviewer: render the Markdown and confirm the table layout looks correct on GitHub