### PR TITLE
test(bot): cover GeneralHandler.invite

### DIFF
--- a/packages/bot/tests/generalCommand.test.ts
+++ b/packages/bot/tests/generalCommand.test.ts
@@ -163,6 +163,68 @@ describe('GeneralHandler.affixes', () => {
   });
 });
 
+describe('GeneralHandler.invite', () => {
+  it('sends fallback message when applicationId is missing and config.DISCORD_APPLICATION_ID is unset', async () => {
+    const original = config.DISCORD_APPLICATION_ID;
+    Object.defineProperty(config, 'DISCORD_APPLICATION_ID', {
+      value: null,
+      writable: true,
+      configurable: true,
+    });
+
+    try {
+      const handler = new GeneralHandler(0, null);
+      const ctx = makeCtx();
+
+      await handler.invite(ctx);
+
+      expect(ctx.send).toHaveBeenCalledOnce();
+      const [content, options] = vi.mocked(ctx.send).mock.calls[0];
+      expect(content).toBe(
+        '❌ Application ID not available. Set config.DISCORD_APPLICATION_ID in your environment.',
+      );
+      expect(options).toBeUndefined();
+      expect(content).not.toContain('https://discord.com');
+    } finally {
+      Object.defineProperty(config, 'DISCORD_APPLICATION_ID', {
+        value: original,
+        writable: true,
+        configurable: true,
+      });
+    }
+  });
+
+  it('builds OAuth URL with constructor applicationId, scope=bot, and BOT_INVITE_PERMISSIONS', async () => {
+    const handler = new GeneralHandler(0, '67890');
+    const ctx = makeCtx();
+
+    await handler.invite(ctx);
+
+    expect(ctx.send).toHaveBeenCalledOnce();
+    const [content] = vi.mocked(ctx.send).mock.calls[0];
+    expect(content).toContain('client_id=67890');
+    expect(content).toContain('scope=bot');
+    expect(content).toContain(`permissions=${config.BOT_INVITE_PERMISSIONS}`);
+    expect(content).toContain('https://discord.com/api/oauth2/authorize');
+    expect(content).toContain('**Add this bot to a server:**');
+  });
+
+  it('falls back to config.DISCORD_APPLICATION_ID when constructor applicationId is null', async () => {
+    const handler = new GeneralHandler(0, null);
+    const ctx = makeCtx();
+
+    await handler.invite(ctx);
+
+    expect(ctx.send).toHaveBeenCalledOnce();
+    const [content] = vi.mocked(ctx.send).mock.calls[0];
+    // The mocked config value is '12345'
+    expect(content).toContain(`client_id=${config.DISCORD_APPLICATION_ID}`);
+    expect(content).toContain('client_id=12345');
+    expect(content).toContain('scope=bot');
+    expect(content).toContain(`permissions=${config.BOT_INVITE_PERMISSIONS}`);
+  });
+});
+
 describe('GeneralHandler.onVoiceStateUpdate', () => {
   it('disconnects when bot is the only one left', async () => {
     const handler = new GeneralHandler();


### PR DESCRIPTION
## Summary
- Adds a `describe('GeneralHandler.invite')` block in `packages/bot/tests/generalCommand.test.ts` covering the three previously untested branches of the handler.
- No source changes — tests only.

## Branches Covered
1. **No applicationId at all** — when both the constructor arg is null and `config.DISCORD_APPLICATION_ID` is unset, asserts the fallback string is sent and no URL is emitted.
2. **Constructor applicationId** — asserts the OAuth URL contains `client_id=<id>`, `scope=bot`, and `permissions=${BOT_INVITE_PERMISSIONS}`.
3. **`??` fallback precedence** — when constructor applicationId is `null` but `config.DISCORD_APPLICATION_ID` is set, asserts the URL uses the config value.

## Test plan
- [x] `npm -w packages/bot run test` — 249 passing (was 246; +3 new)
- [x] `npm run lint` — clean
- [x] `npm -w packages/bot run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)