### PR TITLE
refactor(session): collapse _cleanupGuildIfEmpty variants

### DIFF
--- a/packages/bot/src/services/sessionService.ts
+++ b/packages/bot/src/services/sessionService.ts
@@ -162,22 +162,7 @@ export class SessionService {
     }
 
     await this.firebase.deleteChannelDoc(active.docId);
-    await this._asyncCleanupGuildIfEmpty(active.guildId);
-  }
-
-  private async _asyncCleanupGuildIfEmpty(guildId: string): Promise<void> {
-    const guildHasChannels = [...this.activeChannels.values()].some(
-      (ac) => ac.guildId === guildId,
-    );
-    if (!guildHasChannels) {
-      this.activeGuilds.delete(guildId);
-      await this.firebase.deleteGuildDoc(guildId);
-      if (this.guildListeners.has(guildId)) {
-        const watch = this.guildListeners.get(guildId);
-        watch?.unsubscribe();
-        this.guildListeners.delete(guildId);
-      }
-    }
+    await this._cleanupGuildIfEmpty(active.guildId, { deleteFirestoreDoc: true });
   }
 
   handleCollectionRemoved(change: {
@@ -194,21 +179,27 @@ export class SessionService {
         this.channelListeners.delete(channelId);
       }
       logger.info(`Channel ${channelId} removed from tracking`);
-      this._cleanupGuildIfEmpty(active.guildId);
+      void this._cleanupGuildIfEmpty(active.guildId, { deleteFirestoreDoc: false });
     }
   }
 
-  private _cleanupGuildIfEmpty(guildId: string): void {
+  private async _cleanupGuildIfEmpty(
+    guildId: string,
+    { deleteFirestoreDoc }: { deleteFirestoreDoc: boolean },
+  ): Promise<void> {
     const guildHasChannels = [...this.activeChannels.values()].some(
       (ac) => ac.guildId === guildId,
     );
-    if (!guildHasChannels) {
-      this.activeGuilds.delete(guildId);
-      if (this.guildListeners.has(guildId)) {
-        const watch = this.guildListeners.get(guildId);
-        watch?.unsubscribe();
-        this.guildListeners.delete(guildId);
-      }
+    if (guildHasChannels) return;
+
+    this.activeGuilds.delete(guildId);
+    if (deleteFirestoreDoc) {
+      await this.firebase.deleteGuildDoc(guildId);
+    }
+    if (this.guildListeners.has(guildId)) {
+      const watch = this.guildListeners.get(guildId);
+      watch?.unsubscribe();
+      this.guildListeners.delete(guildId);
     }
   }
 


### PR DESCRIPTION
## Summary

`SessionService` had two near-identical guild-cleanup helpers — `_asyncCleanupGuildIfEmpty` (used by `cleanupChannel`) and `_cleanupGuildIfEmpty` (used by `handleCollectionRemoved`). They shared the same active-channel scan, the same `activeGuilds`/`guildListeners` cleanup, and only differed in whether they also deleted the Firestore guild doc.

Collapsed them into a single private method:

```ts
private async _cleanupGuildIfEmpty(
  guildId: string,
  { deleteFirestoreDoc }: { deleteFirestoreDoc: boolean },
): Promise<void>
```

- `cleanupChannel` calls it with `{ deleteFirestoreDoc: true }` and awaits it (same behavior as before).
- `handleCollectionRemoved` calls it with `{ deleteFirestoreDoc: false }` via `void` (same fire-and-forget semantics as the original sync variant — no awaitable Firestore work happens in that branch).

## Test plan

- [x] `npx eslint packages/`
- [x] `npm -w packages/shared run typecheck`
- [x] `npm -w packages/bot run typecheck`
- [x] `npm -w packages/bot run test` (260 passed, 5 skipped — same baseline)

Generated with [Claude Code](https://claude.com/claude-code)