### PR TITLE
refactor(activity): replace console.error/warn with reportError

### DIFF
--- a/activity/src/discordSdk.ts
+++ b/activity/src/discordSdk.ts
@@ -120,7 +120,7 @@ export async function getParticipants(): Promise<DiscordParticipant[]> {
       username: (p.username ?? '') as string,
     }));
   } catch (e) {
-    console.warn('[DiscordSDK] Failed to get participants:', e);
+    reportError(e, { tag: 'discordSdk.getParticipants' });
     return [];
   }
 }

--- a/activity/src/firebase.ts
+++ b/activity/src/firebase.ts
@@ -3,6 +3,7 @@ import { initializeApp } from 'firebase/app';
 import { getFirestore } from 'firebase/firestore';
 import { getFunctions } from 'firebase/functions';
 import { getAuth, signInAnonymously } from 'firebase/auth';
+import { reportError } from './lib/sentry';
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -27,7 +28,7 @@ try {
   // The promise is not awaited here — Firebase SDK queues callable requests
   // until auth resolves, so functions called after import will work correctly.
   signInAnonymously(auth).catch((err) => {
-    console.warn('[Wheelson] Anonymous auth failed:', err);
+    reportError(err, { tag: 'firebase.signIn' });
   });
 } catch {
   // No valid Firebase config (e.g. Storybook) — auth features are unavailable.

--- a/activity/src/hooks/useCharacterLookup.ts
+++ b/activity/src/hooks/useCharacterLookup.ts
@@ -3,6 +3,7 @@ import { httpsCallable } from 'firebase/functions';
 import { functions } from '../firebase';
 import { useAppStore } from '../store/store';
 import { lookupCharacterProfile } from '../services/raiderioService';
+import { reportError } from '../lib/sentry';
 import { toCharacterClass } from '@mythicplus/shared';
 import type { CharacterClass, Role, Utility } from '@mythicplus/shared';
 
@@ -63,7 +64,7 @@ export function useCharacterLookup() {
       return result.data;
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Character lookup failed';
-      console.warn('[Wheelson] lookupCharacter callable failed:', err);
+      reportError(err, { tag: 'useCharacterLookup.lookup' });
       setError(message);
       return null;
     } finally {

--- a/activity/src/hooks/useDungeonSuggestions.ts
+++ b/activity/src/hooks/useDungeonSuggestions.ts
@@ -5,6 +5,7 @@ import type { CharacterDungeonScores } from '../services/raiderioMythicPlus';
 import { computeDungeonRanking } from '../lib/dungeonSuggestions';
 import type { DungeonSuggestionsState } from '../lib/dungeonSuggestions';
 import type { WoWPlayer } from '../types';
+import { reportError } from '../lib/sentry';
 
 const DEFAULT_REGION = 'us';
 
@@ -163,7 +164,7 @@ export function useDungeonSuggestions(
         } else {
           characters.push(null);
           serviceErrors += 1;
-          console.warn('[Wheelson] Dungeon suggestions fetch failed:', r.reason);
+          reportError(r.reason, { tag: 'useDungeonSuggestions.fetch' });
         }
       }
 

--- a/activity/src/services/firestoreService.ts
+++ b/activity/src/services/firestoreService.ts
@@ -141,7 +141,10 @@ class FirestoreSessionService implements SessionService {
         if (docSnap.exists()) {
           useAppStore.getState().setChannelData(docSnap.data() as ChannelData);
         } else {
-          console.warn('[Wheelson] No doc at channels/' + channelId);
+          reportError(new Error(`No doc at channels/${channelId}`), {
+            tag: 'firestoreService.channelDocMissing',
+            extra: { channelId },
+          });
         }
       },
       (error) => {
@@ -340,7 +343,10 @@ class FirestoreSessionService implements SessionService {
 
   async createGuildEntry(guildId: string, discordChannelId: string | null): Promise<void> {
     if (!/^\d+$/.test(guildId) && guildId !== 'demo-guild') {
-      console.error('[Wheelson] Invalid guild ID:', guildId);
+      reportError(new Error(`Invalid guild ID: ${guildId}`), {
+        tag: 'firestoreService.createGuildEntry',
+        extra: { guildId },
+      });
       return;
     }
 

--- a/activity/src/services/raiderioService.ts
+++ b/activity/src/services/raiderioService.ts
@@ -1,5 +1,6 @@
 // Note: This endpoint is not part of Raider.io's official public API and may change without notice.
 // Only used by demo mode — production lookups go through the `lookupCharacter` Cloud Function.
+import { reportError } from '../lib/sentry';
 
 interface RaiderioProfileResponse {
   name: string;
@@ -47,7 +48,7 @@ export async function lookupCharacterProfile(
       thumbnailUrl,
     };
   } catch (err) {
-    console.warn('[Wheelson] Raider.io profile lookup failed:', err);
+    reportError(err, { tag: 'raiderioService.fetchProfile' });
     return null;
   }
 }


### PR DESCRIPTION
## Summary

Activity error handling is supposed to route through `reportError(err, { tag })` from `lib/sentry.ts` so failures land in Sentry with tagged triage context (PR #465). Six error sites were still using `console.warn` / `console.error`, which are invisible in production. This PR routes all of them through `reportError`.

Files changed:

- `activity/src/services/firestoreService.ts` - missing-channel-doc and invalid-guild-ID checks now report with descriptive Error + extra context.
- `activity/src/firebase.ts` - anonymous-auth catch (added `reportError` import).
- `activity/src/discordSdk.ts` - `getParticipants` catch (already imported `reportError`).
- `activity/src/hooks/useDungeonSuggestions.ts` - per-lookup `Promise.allSettled` rejection (added import).
- `activity/src/hooks/useCharacterLookup.ts` - callable-failure catch (added import).
- `activity/src/services/raiderioService.ts` - profile-fetch catch (added import).

The `console.info` startup log in `firebase.ts` ('Firebase Auth not initialized') and the retry-progress `console.info` in `firestoreService.ts` are intentionally untouched - they're operational status, not errors. Same goes for the `console.warn` sites in `main.tsx`, `routing.ts`, and `discordSdk.ts:85` that warn about missing config / unknown routes (operational, not exception handling).

## Test plan

- [x] `cd activity && npm run typecheck` - clean
- [x] `cd activity && npm run build` - clean
- [x] `npm run lint` - clean
- [ ] No UI behavior change, Playwright skipped per theme guidance

Generated as part of overnight theme T19 (consistency cleanup).