### PR TITLE
perf(activity): parallelize toggleSitOut on spin

### DIFF
--- a/activity/src/views/LobbyView.tsx
+++ b/activity/src/views/LobbyView.tsx
@@ -51,13 +51,17 @@ export function LobbyView({ onNavigate }: LobbyViewProps) {
     try {
       setIsCalculating(true);
 
-      // Auto-sit-out players missing a role
+      // Auto-sit-out players missing a role.
+      // Each toggleSitOut runs its own Firestore transaction (read+write
+      // round trip), so issuing them in parallel converts O(N) latency to
+      // O(1). The underlying writes use commutative arrayUnion ops, so
+      // there's no ordering hazard.
       const { missingRole } = categorizeUnreadyPlayers(players, sittingOut);
-      for (const p of missingRole) {
-        if (p.discordId && !sittingOut.includes(p.discordId)) {
-          await service.toggleSitOut(p.discordId);
-        }
-      }
+      await Promise.all(
+        missingRole
+          .filter((p) => p.discordId && !sittingOut.includes(p.discordId))
+          .map((p) => service.toggleSitOut(p.discordId!)),
+      );
 
       if (useAppStore.getState().isDemoMode) {
         onNavigate('wheels');


### PR DESCRIPTION
## Summary

`LobbyView.doSpin` previously awaited `service.toggleSitOut` serially per missing-role player, blocking each spin on N Firestore transactions (each a read+write round trip) before the wheel even started spinning. This converts that serial fan-out into a single `Promise.all`, taking spin start latency from O(N) to O(1) round trips.

The underlying writes use commutative `arrayUnion` / `arrayRemove` ops on `sittingOut`, so there is no ordering hazard from issuing them concurrently — the final document state is identical regardless of completion order.

## Why this is safe

- Observable behavior is unchanged — missing-role players are still moved to `sittingOut` before `service.requestSpin()` is awaited.
- No DOM change, so existing visual snapshots are unaffected (Playwright snapshot regen skipped intentionally).
- Each `toggleSitOut` already runs in its own `runTransaction`; concurrent transactions on the same doc serialize on the Firestore side, but issuing them concurrently lets the round-trip latencies overlap.

## Test plan

- [x] `cd activity && npm run typecheck`
- [x] `cd activity && npm run build`
- [x] `npm run lint`

Generated overnight by automation as theme T21.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>