### PR TITLE
refactor(bot): extract getDebugPlayers fixture

### DIFF
--- a/packages/bot/src/core/debugFixtures.ts
+++ b/packages/bot/src/core/debugFixtures.ts
@@ -1,0 +1,33 @@
+import {
+  ROLE_BREZ,
+  ROLE_HEALER,
+  ROLE_HEALER_OFFSPEC,
+  ROLE_LUST,
+  ROLE_MELEE,
+  ROLE_MELEE_OFFSPEC,
+  ROLE_RANGED,
+  ROLE_TANK,
+  ROLE_TANK_OFFSPEC,
+  WoWPlayer,
+} from '@mythicplus/shared';
+
+export function getDebugPlayers(): WoWPlayer[] {
+  // Classes are assigned to match each player's role/utility combination
+  // (e.g. brez classes for the brez carriers, lust classes for the lusters)
+  // so debug-mode wheels render real class colors instead of the null fallback.
+  return [
+    WoWPlayer.create('Martz', [ROLE_HEALER, ROLE_TANK_OFFSPEC, ROLE_MELEE_OFFSPEC, ROLE_BREZ], '', '', null, 'Druid'),
+    WoWPlayer.create('KingofSkillz', [ROLE_RANGED, ROLE_LUST], '', '', null, 'Mage'),
+    WoWPlayer.create('chaoswaffles', [ROLE_MELEE, ROLE_TANK_OFFSPEC], '', '', null, 'Death Knight'),
+    WoWPlayer.create('Upartyhardy', [ROLE_RANGED], '', '', null, 'Hunter'),
+    WoWPlayer.create('Pandemonium', [ROLE_TANK, ROLE_MELEE_OFFSPEC, ROLE_BREZ], '', '', null, 'Death Knight'),
+    WoWPlayer.create('Will', [ROLE_MELEE], '', '', null, 'Rogue'),
+    WoWPlayer.create('Tytanium', [ROLE_RANGED, ROLE_HEALER_OFFSPEC, ROLE_LUST], '', '', null, 'Shaman'),
+    WoWPlayer.create('hammer13', [ROLE_MELEE], '', '', null, 'Demon Hunter'),
+    WoWPlayer.create('Ultra9', [ROLE_RANGED, ROLE_LUST], '', '', null, 'Mage'),
+    WoWPlayer.create('DrZoidberg', [ROLE_RANGED], '', '', null, 'Warlock'),
+    WoWPlayer.create('Player1x', [ROLE_RANGED, ROLE_HEALER_OFFSPEC, ROLE_LUST], '', '', null, 'Evoker'),
+    WoWPlayer.create('lizardtotem', [ROLE_HEALER, ROLE_MELEE_OFFSPEC], '', '', null, 'Shaman'),
+    WoWPlayer.create('rorschach128', [ROLE_MELEE], '', '', null, 'Monk'),
+  ];
+}

--- a/packages/bot/src/core/utils.ts
+++ b/packages/bot/src/core/utils.ts
@@ -1,15 +1,4 @@
-import {
-  ROLE_BREZ,
-  ROLE_HEALER,
-  ROLE_HEALER_OFFSPEC,
-  ROLE_LUST,
-  ROLE_MELEE,
-  ROLE_MELEE_OFFSPEC,
-  ROLE_RANGED,
-  ROLE_TANK,
-  ROLE_TANK_OFFSPEC,
-  WoWPlayer,
-} from '@mythicplus/shared';
+import { WoWPlayer } from '@mythicplus/shared';
 import { getPreferenceService } from './preferenceService.js';
 
 export interface DiscordMember {
@@ -72,25 +61,4 @@ export function getPlayerFromMember(member: DiscordMember): WoWPlayer {
 
 export function getPlayerList(members: DiscordMember[]): WoWPlayer[] {
   return members.map(getPlayerFromMember);
-}
-
-export function getDebugPlayers(): WoWPlayer[] {
-  // Classes are assigned to match each player's role/utility combination
-  // (e.g. brez classes for the brez carriers, lust classes for the lusters)
-  // so debug-mode wheels render real class colors instead of the null fallback.
-  return [
-    WoWPlayer.create('Martz', [ROLE_HEALER, ROLE_TANK_OFFSPEC, ROLE_MELEE_OFFSPEC, ROLE_BREZ], '', '', null, 'Druid'),
-    WoWPlayer.create('KingofSkillz', [ROLE_RANGED, ROLE_LUST], '', '', null, 'Mage'),
-    WoWPlayer.create('chaoswaffles', [ROLE_MELEE, ROLE_TANK_OFFSPEC], '', '', null, 'Death Knight'),
-    WoWPlayer.create('Upartyhardy', [ROLE_RANGED], '', '', null, 'Hunter'),
-    WoWPlayer.create('Pandemonium', [ROLE_TANK, ROLE_MELEE_OFFSPEC, ROLE_BREZ], '', '', null, 'Death Knight'),
-    WoWPlayer.create('Will', [ROLE_MELEE], '', '', null, 'Rogue'),
-    WoWPlayer.create('Tytanium', [ROLE_RANGED, ROLE_HEALER_OFFSPEC, ROLE_LUST], '', '', null, 'Shaman'),
-    WoWPlayer.create('hammer13', [ROLE_MELEE], '', '', null, 'Demon Hunter'),
-    WoWPlayer.create('Ultra9', [ROLE_RANGED, ROLE_LUST], '', '', null, 'Mage'),
-    WoWPlayer.create('DrZoidberg', [ROLE_RANGED], '', '', null, 'Warlock'),
-    WoWPlayer.create('Player1x', [ROLE_RANGED, ROLE_HEALER_OFFSPEC, ROLE_LUST], '', '', null, 'Evoker'),
-    WoWPlayer.create('lizardtotem', [ROLE_HEALER, ROLE_MELEE_OFFSPEC], '', '', null, 'Shaman'),
-    WoWPlayer.create('rorschach128', [ROLE_MELEE], '', '', null, 'Monk'),
-  ];
 }

--- a/packages/bot/src/services/groupService.ts
+++ b/packages/bot/src/services/groupService.ts
@@ -1,6 +1,7 @@
 import { WoWGroup, WoWPlayer, createMythicPlusGroups, setGroupHistory, todayPST } from '@mythicplus/shared';
 import { announceGroup, type Sendable } from '../core/groupUi.js';
-import { getDebugPlayers, getPlayerList, type DiscordMember, type TypingChannel } from '../core/utils.js';
+import { getPlayerList, type DiscordMember, type TypingChannel } from '../core/utils.js';
+import { getDebugPlayers } from '../core/debugFixtures.js';
 import { FirebaseService } from '../core/firebaseService.js';
 import logger from '../core/logger.js';
 

--- a/packages/bot/tests/debugFixtures.test.ts
+++ b/packages/bot/tests/debugFixtures.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { getDebugPlayers } from '../src/core/debugFixtures.js';
+
+describe('getDebugPlayers', () => {
+  it('returns valid list of WoWPlayers', () => {
+    const players = getDebugPlayers();
+    expect(players.length).toBeGreaterThan(0);
+    for (const player of players) {
+      expect(player.name).toBeTruthy();
+      expect(player.hasRoles()).toBe(true);
+    }
+  });
+});

--- a/packages/bot/tests/groupService.test.ts
+++ b/packages/bot/tests/groupService.test.ts
@@ -36,12 +36,15 @@ vi.mock('../src/core/logger.js', () => ({
 
 vi.mock('../src/core/utils.js', () => ({
   getPlayerList: vi.fn(),
-  getDebugPlayers: vi.fn(),
   getPlayerFromMember: vi.fn(),
   getWowName: vi.fn(),
   getMaskedName: vi.fn((n: string) => '?'.repeat(n.length)),
   showLongTyping: vi.fn().mockResolvedValue(undefined),
   showShortTyping: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../src/core/debugFixtures.js', () => ({
+  getDebugPlayers: vi.fn(),
 }));
 
 vi.mock('../src/core/groupUi.js', () => ({
@@ -57,7 +60,8 @@ vi.mock('../src/core/preferenceService.js', () => ({
 }));
 
 import { GroupService, type CommandContext } from '../src/services/groupService.js';
-import { getPlayerList, getDebugPlayers } from '../src/core/utils.js';
+import { getPlayerList } from '../src/core/utils.js';
+import { getDebugPlayers } from '../src/core/debugFixtures.js';
 import { announceGroup } from '../src/core/groupUi.js';
 import { createMythicPlusGroups, setGroupHistory } from '@mythicplus/shared';
 

--- a/packages/bot/tests/groupsCommand.test.ts
+++ b/packages/bot/tests/groupsCommand.test.ts
@@ -41,7 +41,6 @@ vi.mock('../src/core/firebaseService.js', () => ({
 
 vi.mock('../src/core/utils.js', () => ({
   getPlayerList: vi.fn(),
-  getDebugPlayers: vi.fn(),
   getPlayerFromMember: vi.fn(),
   getWowName: vi.fn(),
   getMaskedName: vi.fn((n: string) => '?'.repeat(n.length)),

--- a/packages/bot/tests/sessionService.test.ts
+++ b/packages/bot/tests/sessionService.test.ts
@@ -15,7 +15,6 @@ vi.mock('../src/core/firebaseService.js', () => ({
 
 vi.mock('../src/core/utils.js', () => ({
   getPlayerList: vi.fn(),
-  getDebugPlayers: vi.fn(),
   getPlayerFromMember: vi.fn(),
   getWowName: vi.fn(),
   getMaskedName: vi.fn((n: string) => '?'.repeat(n.length)),

--- a/packages/bot/tests/utils.test.ts
+++ b/packages/bot/tests/utils.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   getWowName,
   getMaskedName,
-  getDebugPlayers,
   getPlayerList,
   showLongTyping,
   showShortTyping,
@@ -56,17 +55,6 @@ describe('getWowName', () => {
       toString: () => 'User.Name',
     };
     expect(getWowName(member3)).toBe('UserName');
-  });
-});
-
-describe('getDebugPlayers', () => {
-  it('returns valid list of WoWPlayers', () => {
-    const players = getDebugPlayers();
-    expect(players.length).toBeGreaterThan(0);
-    for (const player of players) {
-      expect(player.name).toBeTruthy();
-      expect(player.hasRoles()).toBe(true);
-    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Move `getDebugPlayers()` (13 hardcoded `WoWPlayer.create` rows used only by debug-mode group spinning) out of `packages/bot/src/core/utils.ts` (Discord-member helpers) into a new `packages/bot/src/core/debugFixtures.ts` module
- Update `GroupService` and the `groupService.test.ts` mock setup to import the fixture from its new location
- Move the dedicated `getDebugPlayers` unit test into `packages/bot/tests/debugFixtures.test.ts`
- Drop the now-unused `getDebugPlayers` mock entries from `sessionService.test.ts` and `groupsCommand.test.ts` (their underlying source files never imported it)

## Why
`utils.ts` is meant for Discord-member helpers (`getWowName`, `getPlayerFromMember`, typing helpers). The fixture data forced nine `ROLE_*` imports on a file that otherwise had no use for them and obscured the module's purpose.

## Test plan
- [x] `npm run lint`
- [x] `npm -w packages/shared run typecheck && npm -w packages/bot run typecheck`
- [x] `npm -w packages/bot run test` (260 passing)

Theme: T15

Generated with [Claude Code](https://claude.com/claude-code)