### PR TITLE
refactor(shared): validate WoWPlayer.fromDict inputs

### DIFF
--- a/packages/bot/tests/models.test.ts
+++ b/packages/bot/tests/models.test.ts
@@ -209,6 +209,143 @@ describe('WoWPlayer', () => {
       expect(player.hasRoles()).toBe(false);
       expect(player.discordId).toBe('503');
     });
+
+    it('coerces non-boolean truthy/falsy legacy roles values', () => {
+      const data = {
+        name: 'Truthy',
+        discordId: '504',
+        roles: {
+          tankMain: 1,
+          healerMain: 0,
+          offhealer: 'yes',
+          offranged: '',
+          hasBrez: {},
+          hasLust: null,
+        },
+      };
+      const player = WoWPlayer.fromDict(data);
+      expect(player.tankMain).toBe(true);
+      expect(player.healerMain).toBe(false);
+      expect(player.offhealer).toBe(true);
+      expect(player.offranged).toBe(false);
+      expect(player.hasBrez).toBe(true);
+      expect(player.hasLust).toBe(false);
+    });
+  });
+
+  describe('fromDict input validation', () => {
+    it('rejects unknown mainRole strings, returning null mainRole', () => {
+      const data = {
+        name: 'Wizard',
+        discordId: '600',
+        mainRole: 'wizard',
+        offspecs: [],
+        utilities: [],
+      };
+      const player = WoWPlayer.fromDict(data);
+      expect(player.mainRole).toBeNull();
+      expect(player.hasRoles()).toBe(false);
+    });
+
+    it('rejects non-string mainRole (number) as null', () => {
+      const data = {
+        name: 'NumRole',
+        discordId: '601',
+        mainRole: 42,
+        offspecs: [],
+        utilities: [],
+      };
+      const player = WoWPlayer.fromDict(data);
+      expect(player.mainRole).toBeNull();
+    });
+
+    it('treats null mainRole as null', () => {
+      const data = {
+        name: 'NullRole',
+        discordId: '602',
+        mainRole: null,
+        offspecs: [],
+        utilities: [],
+      };
+      const player = WoWPlayer.fromDict(data);
+      expect(player.mainRole).toBeNull();
+    });
+
+    it('filters out garbage entries in offspecs while keeping valid roles', () => {
+      const data = {
+        name: 'MixedOff',
+        discordId: '603',
+        mainRole: 'tank',
+        offspecs: ['healer', 'wizard', 99, null, 'melee'],
+        utilities: [],
+      };
+      const player = WoWPlayer.fromDict(data);
+      expect(player.mainRole).toBe('tank');
+      expect(player.offhealer).toBe(true);
+      expect(player.offmelee).toBe(true);
+      expect(player.offranged).toBe(false);
+      expect(player.offtank).toBe(false);
+    });
+
+    it('handles non-array offspecs by yielding empty offspecs', () => {
+      const data = {
+        name: 'BadOff',
+        discordId: '604',
+        mainRole: 'healer',
+        offspecs: 'tank',
+        utilities: [],
+      };
+      const player = WoWPlayer.fromDict(data);
+      expect(player.mainRole).toBe('healer');
+      expect(player.offtank).toBe(false);
+      expect(player.offhealer).toBe(false);
+    });
+
+    it('filters out garbage entries in utilities while keeping valid ones', () => {
+      const data = {
+        name: 'MixedUtil',
+        discordId: '605',
+        mainRole: 'ranged',
+        offspecs: [],
+        utilities: ['brez', 'invisibility', 7, 'lust'],
+      };
+      const player = WoWPlayer.fromDict(data);
+      expect(player.hasBrez).toBe(true);
+      expect(player.hasLust).toBe(true);
+    });
+
+    it('handles non-array utilities by yielding empty utilities', () => {
+      const data = {
+        name: 'BadUtil',
+        discordId: '606',
+        mainRole: 'melee',
+        offspecs: [],
+        utilities: { brez: true },
+      };
+      const player = WoWPlayer.fromDict(data);
+      expect(player.hasBrez).toBe(false);
+      expect(player.hasLust).toBe(false);
+    });
+
+    it('round-trips create -> toDict -> fromDict preserving all fields', () => {
+      const original = WoWPlayer.create(
+        'RoundTrip',
+        [ROLE_RANGED, ROLE_MELEE_OFFSPEC, ROLE_HEALER_OFFSPEC, ROLE_BREZ, ROLE_LUST],
+        '700',
+        'RoundTrip-Sargeras',
+      );
+      const restored = WoWPlayer.fromDict(original.toDict());
+      expect(restored.name).toBe(original.name);
+      expect(restored.discordId).toBe(original.discordId);
+      expect(restored.inGameName).toBe(original.inGameName);
+      expect(restored.mainRole).toBe(original.mainRole);
+      expect(restored.offspecs).toEqual([...original.offspecs]);
+      expect(restored.utilities).toEqual([...original.utilities]);
+      expect(restored.hasBrez).toBe(original.hasBrez);
+      expect(restored.hasLust).toBe(original.hasLust);
+      expect(restored.offhealer).toBe(original.offhealer);
+      expect(restored.offmelee).toBe(original.offmelee);
+    });
   });
 });
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -41,6 +41,6 @@ export type {
   WoWGroupDict,
 } from './types.js';
 
-export { CHARACTER_CLASSES, toCharacterClass } from './types.js';
+export { CHARACTER_CLASSES, toCharacterClass, toRole, toUtility } from './types.js';
 
 export { todayPST } from './dateHelpers.js';

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -10,7 +10,7 @@ import {
   ROLE_TANK,
   ROLE_TANK_OFFSPEC,
 } from './config.js';
-import { toCharacterClass } from './types.js';
+import { toCharacterClass, toRole, toUtility } from './types.js';
 import type { CharacterClass, Role, Utility, WoWGroupDict, WoWPlayerDict } from './types.js';
 
 export class WoWPlayer {
@@ -254,28 +254,33 @@ export class WoWPlayer {
 
     // New compact format: mainRole/offspecs/utilities
     if ('mainRole' in data || 'offspecs' in data || 'utilities' in data) {
-      const mainRole = (data.mainRole as Role | null) ?? null;
-      const offspecs = (data.offspecs as Role[]) ?? [];
-      const utilities = (data.utilities as Utility[]) ?? [];
+      const mainRole = toRole(data.mainRole);
+      const offspecs: Role[] = Array.isArray(data.offspecs)
+        ? data.offspecs.map(toRole).filter((r): r is Role => r !== null)
+        : [];
+      const utilities: Utility[] = Array.isArray(data.utilities)
+        ? data.utilities.map(toUtility).filter((u): u is Utility => u !== null)
+        : [];
       return new WoWPlayer(name, discordId, mainRole, offspecs, utilities, inGameName, mediaUrl, characterClass);
     }
 
-    // Legacy format: nested roles object with boolean flags
-    const roles = (data.roles ?? {}) as Record<string, boolean>;
+    // Legacy format: nested roles object with boolean flags. Coerce defensively
+    // since old Firestore docs may contain non-boolean values for these fields.
+    const roles = (data.roles ?? {}) as Record<string, unknown>;
     return WoWPlayer.fromFlags({
       name,
       discordId,
       inGameName,
-      tankMain: roles.tankMain ?? false,
-      healerMain: roles.healerMain ?? false,
-      ranged: roles.ranged ?? false,
-      melee: roles.melee ?? false,
-      offtank: roles.offtank ?? false,
-      offhealer: roles.offhealer ?? false,
-      offranged: roles.offranged ?? false,
-      offmelee: roles.offmelee ?? false,
-      hasBrez: roles.hasBrez ?? false,
-      hasLust: roles.hasLust ?? false,
+      tankMain: Boolean(roles.tankMain),
+      healerMain: Boolean(roles.healerMain),
+      ranged: Boolean(roles.ranged),
+      melee: Boolean(roles.melee),
+      offtank: Boolean(roles.offtank),
+      offhealer: Boolean(roles.offhealer),
+      offranged: Boolean(roles.offranged),
+      offmelee: Boolean(roles.offmelee),
+      hasBrez: Boolean(roles.hasBrez),
+      hasLust: Boolean(roles.hasLust),
     });
   }
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -27,6 +27,21 @@ export function toCharacterClass(raw: unknown): CharacterClass | null {
   return (CHARACTER_CLASSES as readonly string[]).includes(raw) ? (raw as CharacterClass) : null;
 }
 
+const ROLES: readonly Role[] = ['tank', 'healer', 'ranged', 'melee'];
+const UTILITIES: readonly Utility[] = ['brez', 'lust'];
+
+/** Safely narrow an arbitrary value to Role, or null if it isn't a known role. */
+export function toRole(raw: unknown): Role | null {
+  if (typeof raw !== 'string') return null;
+  return (ROLES as readonly string[]).includes(raw) ? (raw as Role) : null;
+}
+
+/** Safely narrow an arbitrary value to Utility, or null if it isn't a known utility. */
+export function toUtility(raw: unknown): Utility | null {
+  if (typeof raw !== 'string') return null;
+  return (UTILITIES as readonly string[]).includes(raw) ? (raw as Utility) : null;
+}
+
 export interface WoWPlayerDict {
   [key: string]: unknown;
   name: string;


### PR DESCRIPTION
## Summary

`WoWPlayer.fromDict` is the deserialization boundary for Firestore session docs. It was blindly casting raw values to `Role | null`, `Role[]`, `Utility[]` etc., so a corrupt/legacy document could yield a player with `mainRole: 'wizard'` or junk in `offspecs` and the rest of the algorithm would happily run on it.

This PR tightens the boundary while preserving tolerance for legacy data:

- Adds `toRole(raw: unknown): Role | null` and `toUtility(raw: unknown): Utility | null` validators in `packages/shared/src/types.ts`, mirroring the existing `toCharacterClass` pattern.
- Updates the new-format branch of `fromDict` to:
  - narrow `mainRole` via `toRole`,
  - filter `offspecs`/`utilities` through the validators (dropping unknown values),
  - default to `[]` when the field isn't an array.
- Updates the legacy-`roles`-map branch to coerce each flag with `Boolean(...)`, defending against non-boolean values that may exist in old Firestore docs.
- Exports `toRole` / `toUtility` from `@mythicplus/shared` for reuse.

## Test plan

- [x] `npx eslint packages/` clean
- [x] `npm -w packages/shared run typecheck` passes
- [x] `npm -w packages/bot run typecheck` passes
- [x] `cd activity && npm run typecheck` passes
- [x] `npm -w packages/bot run test` (269 passed, 5 skipped)
- [x] `cd packages/shared && npx vitest run` (24 passed)
- [x] New tests in `packages/bot/tests/models.test.ts`:
  - garbage `mainRole` (string `'wizard'`, number, `null`) -> null mainRole
  - garbage entries in `offspecs` filtered out, valid roles kept
  - non-array `offspecs`/`utilities` produce empty arrays
  - legacy `roles` map with non-boolean truthy/falsy values coerced correctly
  - `create() -> toDict() -> fromDict()` round-trip preserves all fields