### PR TITLE
chore(activity): compute grid spin durations from stagger constant

### DIFF
--- a/activity/src/lib/timing.ts
+++ b/activity/src/lib/timing.ts
@@ -2,9 +2,15 @@
 export const CAROUSEL_SPIN_DURATION = 2000;   // ms per wheel in carousel mode
 export const CAROUSEL_ADVANCE_DELAY = 600;    // ms pause after each landing
 // Per-wheel spin durations in grid mode, ordered tank → healer → dps1/2/3.
-// Each wheel lands 500ms after the previous so landings are
+// Each wheel lands GRID_SPIN_STAGGER ms after the previous so landings are
 // individually visible instead of clumping into a single pop.
-export const GRID_SPIN_DURATIONS = [3000, 3500, 4000, 4500, 5000];
+export const GRID_SPIN_BASE_DURATION = 3000;
+export const GRID_SPIN_STAGGER = 400;
+export const GRID_WHEEL_COUNT = 5;
+export const GRID_SPIN_DURATIONS = Array.from(
+  { length: GRID_WHEEL_COUNT },
+  (_, i) => GRID_SPIN_BASE_DURATION + i * GRID_SPIN_STAGGER,
+);
 
 // Auto-advance spotlight timing
 export const SPOTLIGHT_HOLD_DURATION = 1500;  // ms to hold spotlight card center-stage


### PR DESCRIPTION
## Summary
- Replace hardcoded `GRID_SPIN_DURATIONS = [3000, 3500, 4000, 4500, 5000]` with a derivation from `GRID_SPIN_BASE_DURATION` (3000) and `GRID_SPIN_STAGGER` (400) over `GRID_WHEEL_COUNT` (5).
- Reduce the inter-wheel landing gap from 500ms → 400ms for snappier grid-mode reveals.

## Test plan
- [x] `./scripts/verify-activity.sh` (typecheck + build + Storybook + 160 Playwright tests)
- [ ] Spot-check a real spin in grid mode to confirm the reveal feels right

🤖 Generated with [Claude Code](https://claude.com/claude-code)