### PR TITLE
refactor: tighten error handling across bot and activity

### DIFF
--- a/activity/src/hooks/useCharacterLookup.ts
+++ b/activity/src/hooks/useCharacterLookup.ts
@@ -7,6 +7,20 @@ import { reportError } from '../lib/sentry';
 import { toCharacterClass } from '@mythicplus/shared';
 import type { CharacterClass, Role, Utility } from '@mythicplus/shared';
 
+// Callable error codes that indicate user input failed validation rather than
+// an actionable bug — surface them to the user but don't report to Sentry.
+const EXPECTED_LOOKUP_CODES = new Set([
+  'functions/not-found',
+  'functions/invalid-argument',
+  'functions/failed-precondition',
+]);
+
+function isExpectedLookupError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const code = (err as { code?: string }).code;
+  return typeof code === 'string' && EXPECTED_LOOKUP_CODES.has(code);
+}
+
 export interface CharacterData {
   name: string;
   realm: string;
@@ -64,7 +78,9 @@ export function useCharacterLookup() {
       return result.data;
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Character lookup failed';
-      reportError(err, { tag: 'useCharacterLookup.lookup' });
+      if (!isExpectedLookupError(err)) {
+        reportError(err, { tag: 'useCharacterLookup.lookup' });
+      }
       setError(message);
       return null;
     } finally {

--- a/activity/src/hooks/useDungeonSuggestions.ts
+++ b/activity/src/hooks/useDungeonSuggestions.ts
@@ -157,15 +157,24 @@ export function useDungeonSuggestions(
       if (cancelled || controller.signal.aborted) return;
 
       const characters: (CharacterDungeonScores | null)[] = [];
-      let serviceErrors = 0;
+      const failureReasons: unknown[] = [];
       for (const r of results) {
         if (r.status === 'fulfilled') {
           characters.push(r.value);
         } else {
           characters.push(null);
-          serviceErrors += 1;
-          reportError(r.reason, { tag: 'useDungeonSuggestions.fetch' });
+          failureReasons.push(r.reason);
         }
+      }
+      const serviceErrors = failureReasons.length;
+      // Per-character Raider.io failures are tolerated — the UI shows partial
+      // data and the next refetch usually fixes it. Only escalate if every
+      // lookup in the batch failed (Raider.io outage or local network down).
+      if (serviceErrors > 0 && serviceErrors === uniqueLookups.length) {
+        reportError(failureReasons[0], {
+          tag: 'useDungeonSuggestions.fetch',
+          extra: { batchSize: uniqueLookups.length },
+        });
       }
 
       const indexByKey: Record<string, number> = {};

--- a/activity/src/services/firestoreService.ts
+++ b/activity/src/services/firestoreService.ts
@@ -118,7 +118,11 @@ class FirestoreSessionService implements SessionService {
           });
       },
       (error) => {
-        reportError(error, { tag: 'firestoreService.guildListener', extra: { retryCount } });
+        // Report only on the first failure to avoid 5x amplification across the
+        // retry chain. The status-message UX is driven separately by scheduleRetry.
+        if (retryCount === 0) {
+          reportError(error, { tag: 'firestoreService.guildListener' });
+        }
         this.scheduleRetry('guildRetryTimer', 'guild', retryCount, error, () =>
           this.subscribeToGuild(guildId, retryCount + 1),
         );
@@ -165,7 +169,9 @@ class FirestoreSessionService implements SessionService {
         }
       },
       (error) => {
-        reportError(error, { tag: 'firestoreService.channelListener', extra: { retryCount } });
+        if (retryCount === 0) {
+          reportError(error, { tag: 'firestoreService.channelListener' });
+        }
         this.scheduleRetry('channelRetryTimer', 'channel', retryCount, error, () =>
           this.subscribeToChannel(channelId, retryCount + 1),
         );
@@ -196,17 +202,19 @@ class FirestoreSessionService implements SessionService {
 
     // Restore group history from Firestore so the algorithm avoids repeat
     // groupings. Malformed history should never block a spin — fall back to
-    // empty history.
-    let existingRounds: WoWGroupDict[][] = [];
+    // empty history. The try is narrowed to just WoWGroup.fromDict since
+    // parseExistingRounds already returns [] defensively for malformed data
+    // and setGroupHistory doesn't throw.
+    const existingRounds = parseExistingRounds(guildData, today);
+    let rounds: WoWGroup[][];
     try {
-      existingRounds = parseExistingRounds(guildData, today);
-      const rounds = existingRounds.map(round => round.map(g => WoWGroup.fromDict(g)));
-      setGroupHistory(rounds, guildId);
+      rounds = existingRounds.map(round => round.map(g => WoWGroup.fromDict(g)));
     } catch (err) {
       reportError(err, { tag: 'firestoreService.restoreGroupHistory' });
-      existingRounds = [];
-      setGroupHistory([], guildId);
+      rounds = [];
     }
+    setGroupHistory(rounds, guildId);
+    const roundsForPersist: WoWGroupDict[][] = rounds.length === 0 ? [] : existingRounds;
 
     const players = eligibleSpinPlayers(channelData.players, channelData.sittingOut ?? []);
 
@@ -217,7 +225,7 @@ class FirestoreSessionService implements SessionService {
     // Intentionally not awaited — history save should not block the spin.
     if (guildId) {
       const guildDocRef = doc(db, 'guilds', guildId);
-      const wireRounds = encodeGroupHistoryRounds([...existingRounds, groupDicts]);
+      const wireRounds = encodeGroupHistoryRounds([...roundsForPersist, groupDicts]);
       setDoc(guildDocRef, {
         groupHistory: { date: today, rounds: wireRounds },
       }, { merge: true }).catch(err => reportError(err, { tag: 'firestoreService.saveGroupHistory' }));
@@ -367,10 +375,9 @@ class FirestoreSessionService implements SessionService {
 
   async createGuildEntry(guildId: string, discordChannelId: string | null): Promise<void> {
     if (!/^\d+$/.test(guildId) && guildId !== 'demo-guild') {
-      reportError(new Error(`Invalid guild ID: ${guildId}`), {
-        tag: 'firestoreService.createGuildEntry',
-        extra: { guildId },
-      });
+      // Precondition check on URL-derived input — a user opening a malformed
+      // activity link is bad input, not an actionable error.
+      console.warn(`[Wheelson] Invalid guild ID: ${guildId}`);
       return;
     }
 

--- a/activity/src/services/raiderioService.ts
+++ b/activity/src/services/raiderioService.ts
@@ -48,6 +48,12 @@ export async function lookupCharacterProfile(
       thumbnailUrl,
     };
   } catch (err) {
+    // Don't report environment failures (offline, abort, generic fetch failure).
+    // Demo mode is contributor-facing; offline runs of Storybook etc. would
+    // otherwise produce noise without an actionable bug.
+    if (err instanceof Error && (err.name === 'AbortError' || err.name === 'TypeError')) {
+      return null;
+    }
     reportError(err, { tag: 'raiderioService.fetchProfile' });
     return null;
   }

--- a/activity/src/views/WheelsView.tsx
+++ b/activity/src/views/WheelsView.tsx
@@ -128,10 +128,14 @@ export function WheelsView({ onNavigate }: WheelsViewProps) {
       if (store.groupCards.length >= totalFull) return;
       if (store.currentGroupIndex >= totalFull) {
         onNavigate('results', { replace: true });
-        service.finishSequence();
+        service.finishSequence().catch((err) => {
+          reportError(err, { tag: 'WheelsView.finishSequenceEffect' });
+        });
         return;
       }
-      runAutoAdvanceLoop();
+      runAutoAdvanceLoop().catch((err) => {
+        reportError(err, { tag: 'WheelsView.autoAdvanceEffect' });
+      });
     }
   }, [channelData?.revealedGroups, spinSequenceStarted, autoAdvanceRunning]);
 
@@ -325,7 +329,11 @@ export function WheelsView({ onNavigate }: WheelsViewProps) {
     onNavigate('lobby');
     gridRef.current?.grid?.cancelAll();
     useAppStore.getState().resetSpinState();
-    await service.cancelToLobby();
+    try {
+      await service.cancelToLobby();
+    } catch (err) {
+      reportError(err, { tag: 'WheelsView.cancelToLobby' });
+    }
   }, [service, onNavigate]);
 
   const requestBack = useCallback(() => {

--- a/packages/bot/src/commands/groups.ts
+++ b/packages/bot/src/commands/groups.ts
@@ -2,7 +2,7 @@ import { SessionService, type Bot, type Guild } from '../services/sessionService
 import type { CommandContext, GroupService } from '../services/groupService.js';
 import { reportBadGroup } from '../core/issues.js';
 import { ACTIVITY_URL, DISCORD_APPLICATION_ID } from '../core/config.js';
-import logger from '../core/logger.js';
+import { reportError } from '../core/sentry.js';
 
 export interface GroupsContext {
   guild: { id: string } | null;
@@ -46,61 +46,57 @@ export class GroupsHandler {
     this.sessionService = sessionService ?? new SessionService(bot);
   }
 
+  // Errors propagate to the InteractionCreate wrapper in main.ts, which
+  // reports to Sentry with command/guild tags and replies with a generic
+  // ephemeral error message. Catching here would prevent that.
   async wheel(ctx: GroupsContext): Promise<void> {
     await ctx.defer();
-    try {
-      if (!ctx.channel) {
-        throw new Error('Channel context is required for coreWheel');
-      }
-      await this.groupService.coreWheel(ctx as unknown as CommandContext, false);
-    } catch (e) {
-      await ctx.send('❌ An unexpected error occurred. Please try again later.');
-      logger.error(`Error in wheel command: ${e}`);
+    if (!ctx.channel) {
+      throw new Error('Channel context is required for coreWheel');
     }
+    await this.groupService.coreWheel(ctx as unknown as CommandContext, false);
   }
 
   async activity(ctx: ActivityContext, debug = false): Promise<void> {
     await ctx.defer();
-    try {
-      if (!ctx.author.voice?.channel) {
-        await ctx.send('❌ You must be in a voice channel to start an activity.');
-        return;
-      }
-
-      const result = await this.sessionService.getOrCreateSession(ctx, debug);
-      if (!result) {
-        await ctx.send('❌ Failed to create/get session. Is Firebase configured?');
-        return;
-      }
-
-      const [guildId, channelId] = result;
-
-      let inviteUrl = 'N/A';
-      if (DISCORD_APPLICATION_ID && ctx.author.voice.channel.createInvite) {
-        try {
-          const invite = await ctx.author.voice.channel.createInvite();
-          inviteUrl = invite.url;
-        } catch (e) {
-          logger.warn(`Failed to create embedded invite: ${e}`);
-        }
-      }
-
-      const activityUrlBase = ACTIVITY_URL;
-      let msg = '🎮 **Join the Activity!**\n';
-      msg += `**Voice Channel Activity:** ${inviteUrl}\n`;
-
-      if (activityUrlBase) {
-        const directLink = `${activityUrlBase}?guildId=${guildId}&channelId=${channelId}`;
-        msg += `**Browser Link:** [Click Here](${directLink})\n`;
-      } else {
-        msg += '⚠️ `ACTIVITY_URL` not set in .env.';
-      }
-
-      await ctx.send(msg);
-    } catch (e) {
-      await ctx.send('❌ An unexpected error occurred. Please try again later.');
-      logger.error(`Error in activity command: ${e}`);
+    if (!ctx.author.voice?.channel) {
+      await ctx.send('❌ You must be in a voice channel to start an activity.');
+      return;
     }
+
+    const result = await this.sessionService.getOrCreateSession(ctx, debug);
+    if (!result) {
+      await ctx.send('❌ Failed to create/get session. Is Firebase configured?');
+      return;
+    }
+
+    const [guildId, channelId] = result;
+
+    let inviteUrl = 'N/A';
+    if (DISCORD_APPLICATION_ID && ctx.author.voice.channel.createInvite) {
+      try {
+        const invite = await ctx.author.voice.channel.createInvite();
+        inviteUrl = invite.url;
+      } catch (e) {
+        // Invite creation can fail for many benign reasons (missing perms,
+        // channel type, rate limit). The activity link still works without
+        // it; surface to Sentry but don't break the response.
+        reportError(e, { tags: { handler: 'activity.createInvite' } });
+      }
+    }
+
+    const activityUrlBase = ACTIVITY_URL;
+    let msg = '🎮 **Join the Activity!**\n';
+    msg += `**Voice Channel Activity:** ${inviteUrl}\n`;
+
+    if (activityUrlBase) {
+      const directLink = `${activityUrlBase}?guildId=${guildId}&channelId=${channelId}`;
+      msg += `**Browser Link:** [Click Here](${directLink})\n`;
+    } else {
+      msg += '⚠️ `ACTIVITY_URL` not set in .env.';
+    }
+
+    await ctx.send(msg);
   }
 
   async badgroup(
@@ -135,20 +131,15 @@ export class GroupsHandler {
     }
 
     await ctx.defer({ ephemeral: true });
-    try {
-      const issue = await reportBadGroup({
-        reporterName: ctx.author.name,
-        reporterId: ctx.author.id,
-        title,
-        description,
-        players: lastResults.players,
-        groups: lastResults.groups,
-      });
-      await ctx.send(`✅ Bad group reported successfully: ${issue.html_url}`, { ephemeral: true });
-    } catch (e) {
-      logger.error(`Error creating GitHub issue via badgroup command: ${e}`);
-      await ctx.send(`❌ Failed to create issue: ${e}`, { ephemeral: true });
-    }
+    const issue = await reportBadGroup({
+      reporterName: ctx.author.name,
+      reporterId: ctx.author.id,
+      title,
+      description,
+      players: lastResults.players,
+      groups: lastResults.groups,
+    });
+    await ctx.send(`✅ Bad group reported successfully: ${issue.html_url}`, { ephemeral: true });
   }
 
   async onVoiceStateUpdate(

--- a/packages/bot/src/core/firebaseService.ts
+++ b/packages/bot/src/core/firebaseService.ts
@@ -5,6 +5,7 @@ import {
   type WoWGroupDict,
 } from '@mythicplus/shared';
 import logger from './logger.js';
+import { reportError } from './sentry.js';
 import * as config from './config.js';
 
 // Sentinel for Firestore server timestamps.
@@ -285,7 +286,7 @@ export class FirebaseService implements IFirebaseService {
         }
       },
       (...errArgs: unknown[]) => {
-        logger.error(`Bad group report listener error: ${errArgs[0]}`);
+        reportError(errArgs[0], { tags: { handler: 'firebaseService.badGroupReportListener' } });
       },
     );
 
@@ -312,7 +313,7 @@ export class FirebaseService implements IFirebaseService {
         }
       },
       (...errArgs: unknown[]) => {
-        logger.error(`Guild refresh listener error: ${errArgs[0]}`);
+        reportError(errArgs[0], { tags: { handler: 'firebaseService.guildRefreshListener' } });
       },
     );
 
@@ -339,7 +340,7 @@ export class FirebaseService implements IFirebaseService {
         }
       },
       (...errArgs: unknown[]) => {
-        logger.error(`Channel player refresh listener error: ${errArgs[0]}`);
+        reportError(errArgs[0], { tags: { handler: 'firebaseService.channelPlayerRefreshListener' } });
       },
     );
 
@@ -391,7 +392,7 @@ export class FirebaseService implements IFirebaseService {
         }
       },
       (...errArgs: unknown[]) => {
-        logger.error(`Channel removed listener error: ${errArgs[0]}`);
+        reportError(errArgs[0], { tags: { handler: 'firebaseService.channelRemovedListener' } });
       },
     );
 

--- a/packages/bot/src/core/preferenceService.ts
+++ b/packages/bot/src/core/preferenceService.ts
@@ -1,4 +1,5 @@
 import logger from './logger.js';
+import { reportError } from './sentry.js';
 import { toCharacterClass } from '@mythicplus/shared';
 import type { CharacterClass } from '@mythicplus/shared';
 import { FirebaseService, SERVER_TIMESTAMP } from './firebaseService.js';
@@ -71,8 +72,8 @@ export class PreferenceService implements IPreferenceService {
         if (characterClass) this._characterClassCache[discordId] = characterClass;
       }
       logger.info(`Loaded ${Object.keys(docs).length} preferences from Firestore`);
-    } catch {
-      logger.error('Failed to load preferences from Firestore, using local');
+    } catch (err) {
+      reportError(err, { tags: { handler: 'preferenceService.loadCache' } });
       this._loadFromLocal();
     }
   }
@@ -123,8 +124,11 @@ export class PreferenceService implements IPreferenceService {
           if (characterClass) this._characterClassCache[discordId] = characterClass;
           return roles;
         }
-      } catch {
-        logger.error(`Firestore read failed for ${discordId}`);
+      } catch (err) {
+        reportError(err, {
+          tags: { handler: 'preferenceService.getPreference' },
+          extra: { discordId },
+        });
       }
     }
 
@@ -145,8 +149,11 @@ export class PreferenceService implements IPreferenceService {
     if (this._firebaseOk()) {
       try {
         await this._writeFirestorePref(discordId, name, roles, inGameName);
-      } catch {
-        logger.error(`Firestore write failed for ${discordId}`);
+      } catch (err) {
+        reportError(err, {
+          tags: { handler: 'preferenceService.setPreference' },
+          extra: { discordId },
+        });
       }
     }
 
@@ -169,8 +176,11 @@ export class PreferenceService implements IPreferenceService {
     if (this._firebaseOk()) {
       try {
         await this._deleteFirestorePref(discordId);
-      } catch {
-        logger.error(`Firestore delete failed for ${discordId}`);
+      } catch (err) {
+        reportError(err, {
+          tags: { handler: 'preferenceService.clearPreference' },
+          extra: { discordId },
+        });
       }
     }
   }
@@ -212,8 +222,11 @@ export class PreferenceService implements IPreferenceService {
         Reflect.deleteProperty(this._characterClassCache, discordId);
         this._clearNameMapping(discordId);
       }
-    } catch {
-      logger.error(`Firestore refresh failed for ${discordId}`);
+    } catch (err) {
+      reportError(err, {
+        tags: { handler: 'preferenceService.refreshPreference' },
+        extra: { discordId },
+      });
     }
   }
 

--- a/packages/bot/src/main.ts
+++ b/packages/bot/src/main.ts
@@ -34,7 +34,7 @@ import { getWowName, getPlayerList, type DiscordMember } from './core/utils.js';
 import { FirebaseService, DELETE_FIELD } from './core/firebaseService.js';
 import { WoWPlayer, WoWGroup, STATIC_AFFIXES } from '@mythicplus/shared';
 import type { AffixDisplay } from '@mythicplus/shared';
-import { reportBadGroup, submitGithubIssueModal } from './core/issues.js';
+import { reportBadGroup, submitGithubIssueModal, GitHubError } from './core/issues.js';
 import type { GitHubIssueResponse } from './core/issues.js';
 import { getPreferenceService } from './core/preferenceService.js';
 import { IssueTrackingService } from './services/issueTrackingService.js';
@@ -499,13 +499,15 @@ async function main() {
 
         logger.info(`Bad group report processed: ${issue.html_url}`);
       } catch (e) {
-        logger.error(`Failed to process bad group report ${docId}: ${e}`);
+        reportError(e, { tags: { handler: 'badGroupReport' }, extra: { docId } });
       } finally {
-        // Always delete the report doc to prevent reprocessing on restart
+        // Always delete the report doc to prevent reprocessing on restart.
+        // A persistent delete failure would re-fire the same report on every
+        // listener tick, so escalate this rather than swallowing.
         try {
           await firebase.deleteDoc('badGroupReports', docId);
         } catch (delErr) {
-          logger.error(`Failed to delete bad group report doc ${docId}: ${delErr}`);
+          reportError(delErr, { tags: { handler: 'badGroupReportCleanup' }, extra: { docId } });
         }
       }
     });
@@ -549,8 +551,10 @@ async function main() {
         await firebase.updateGuildDoc(guildId, updateData);
         logger.debug(`Refreshed voice channels for guild ${guildId}`);
       } catch (e) {
-        logger.error(`Failed to refresh voice channels for guild ${guildId}: ${e}`);
+        reportError(e, { tags: { handler: 'guildRefresh' }, extra: { guildId } });
       } finally {
+        // Best-effort clear; the refresh fires again on the next request, so
+        // a transient failure here is recoverable. Keep at debug.
         try {
           await firebase.updateGuildDoc(guildId, { refreshRequest: DELETE_FIELD });
         } catch (e) {
@@ -612,7 +616,7 @@ async function main() {
 
         logger.debug(`Refreshed players for channel ${channelId} (${playersData.length} players)`);
       } catch (e) {
-        logger.error(`Failed to refresh players for channel ${channelId}: ${e}`);
+        reportError(e, { tags: { handler: 'channelPlayerRefresh' }, extra: { channelId } });
       }
     });
 
@@ -841,7 +845,14 @@ async function main() {
           const dmHint = dmSent ? '' : '\n(Enable DMs to get notified when this is resolved)';
           await sender.send(`✅ Bad group reported: ${issue.html_url}${dmHint}`);
         } catch (e) {
-          logger.error(`Failed to submit quick badgroup: ${e}`);
+          reportError(e, {
+            tags: {
+              handler: 'submitIssue',
+              kind: 'badgroup',
+              source: 'quick',
+              errorType: e instanceof GitHubError ? 'github' : 'unknown',
+            },
+          });
           const msg = e instanceof Error ? e.message : String(e);
           await sender.send(`❌ Failed to create issue: ${msg}`);
         }
@@ -873,7 +884,14 @@ async function main() {
             const dmHint = dmSent ? '' : '\n(Enable DMs to get notified when this is resolved)';
             await sender.send(`✅ Bug reported: ${issue.html_url}${dmHint}`);
           } catch (e) {
-            logger.error(`Failed to submit quick bug: ${e}`);
+            reportError(e, {
+              tags: {
+                handler: 'submitIssue',
+                kind: 'bug',
+                source: 'quick',
+                errorType: e instanceof GitHubError ? 'github' : 'unknown',
+              },
+            });
             const msg = e instanceof Error ? e.message : String(e);
             await sender.send(`❌ Failed to create issue: ${msg}`);
           }
@@ -945,7 +963,14 @@ async function main() {
             const dmHint = dmSent ? '' : '\n(Enable DMs to get notified when this is resolved)';
             await sender.send(`✅ Feature request created: ${issue.html_url}${dmHint}`);
           } catch (e) {
-            logger.error(`Failed to submit quick feature request: ${e}`);
+            reportError(e, {
+              tags: {
+                handler: 'submitIssue',
+                kind: 'feature',
+                source: 'quick',
+                errorType: e instanceof GitHubError ? 'github' : 'unknown',
+              },
+            });
             const msg = e instanceof Error ? e.message : String(e);
             await sender.send(`❌ Failed to create issue: ${msg}`);
           }
@@ -1142,9 +1167,10 @@ async function main() {
           }
         }
       } catch (syncErr) {
-        // warn (not debug) — role desync is user-visible and worth surfacing
-        // in prod logs even though local role state was already saved.
-        logger.warn(`Failed to sync role changes to active channels: ${syncErr}`);
+        // Role desync is user-visible (the activity will show stale roles
+        // until the next refresh), worth surfacing to Sentry even though
+        // local role state was already saved successfully.
+        reportError(syncErr, { tags: { handler: 'roleSyncAfterSave' } });
       }
       return;
     }
@@ -1189,7 +1215,14 @@ async function main() {
         const dmHint = dmSent ? '' : '\n(Enable DMs to get notified when this is resolved)';
         await interaction.editReply(`✅ Issue created: ${issue.html_url}${dmHint}`);
       } catch (e) {
-        logger.error(`Failed to submit ${customId}: ${e}`);
+        reportError(e, {
+          tags: {
+            handler: 'submitIssue',
+            kind: customId === 'bug_modal' ? 'bug' : 'feature',
+            source: 'modal',
+            errorType: e instanceof GitHubError ? 'github' : 'unknown',
+          },
+        });
         const msg = e instanceof Error ? e.message : String(e);
         await interaction.editReply(`❌ Failed to create issue: ${msg}`);
       }
@@ -1221,7 +1254,14 @@ async function main() {
         const dmHint = dmSent ? '' : '\n(Enable DMs to get notified when this is resolved)';
         await interaction.editReply(`✅ Bad group reported: ${issue.html_url}${dmHint}`);
       } catch (e) {
-        logger.error(`Failed to submit badgroup modal: ${e}`);
+        reportError(e, {
+          tags: {
+            handler: 'submitIssue',
+            kind: 'badgroup',
+            source: 'modal',
+            errorType: e instanceof GitHubError ? 'github' : 'unknown',
+          },
+        });
         const msg = e instanceof Error ? e.message : String(e);
         await interaction.editReply(`❌ Failed to create issue: ${msg}`);
       }

--- a/packages/bot/tests/groupsCommand.test.ts
+++ b/packages/bot/tests/groupsCommand.test.ts
@@ -390,7 +390,7 @@ describe('GroupsHandler.wheel', () => {
     expect(logger.error).not.toHaveBeenCalled();
   });
 
-  it('catches missing-channel error, sends fallback, and logs', async () => {
+  it('throws when channel context is missing (caller wraps for Sentry)', async () => {
     const groupService = makeStubGroupService();
     const handler = new GroupsHandler(
       makeMockBot() as any, // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -398,22 +398,19 @@ describe('GroupsHandler.wheel', () => {
       makeMockSessionService(),
     );
 
-    // ctx.channel is omitted so the handler should throw internally.
+    // ctx.channel is omitted so the handler should throw — the outer
+    // InteractionCreate wrapper in main.ts handles the user reply + Sentry.
     const ctx = makeCtx();
 
-    await handler.wheel(ctx);
-
+    await expect(handler.wheel(ctx)).rejects.toThrow(
+      'Channel context is required for coreWheel',
+    );
     expect(ctx.defer).toHaveBeenCalledOnce();
     expect(groupService.coreWheel).not.toHaveBeenCalled();
-    expect(ctx.send).toHaveBeenCalledWith(
-      '❌ An unexpected error occurred. Please try again later.',
-    );
-    expect(logger.error).toHaveBeenCalledOnce();
-    const errMsg = vi.mocked(logger.error).mock.calls[0][0] as unknown as string;
-    expect(errMsg).toContain('Channel context is required for coreWheel');
+    expect(ctx.send).not.toHaveBeenCalled();
   });
 
-  it('catches errors thrown by groupService.coreWheel and logs them', async () => {
+  it('propagates errors from groupService.coreWheel to caller', async () => {
     const groupService = makeStubGroupService();
     vi.mocked(groupService.coreWheel).mockRejectedValue(new Error('boom'));
 
@@ -429,16 +426,9 @@ describe('GroupsHandler.wheel', () => {
       sendTyping: vi.fn().mockResolvedValue(undefined),
     };
 
-    await handler.wheel(ctx);
-
+    await expect(handler.wheel(ctx)).rejects.toThrow('boom');
     expect(ctx.defer).toHaveBeenCalledOnce();
     expect(groupService.coreWheel).toHaveBeenCalledOnce();
-    expect(ctx.send).toHaveBeenCalledWith(
-      '❌ An unexpected error occurred. Please try again later.',
-    );
-    expect(logger.error).toHaveBeenCalledOnce();
-    const errMsg = vi.mocked(logger.error).mock.calls[0][0] as unknown as string;
-    expect(errMsg).toContain('Error in wheel command');
-    expect(errMsg).toContain('boom');
+    expect(ctx.send).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Three sweeps bundled — addresses logging gaps, noise, and overly broad try/catch blocks identified in audits triggered by the false-positive Sentry alert from #496.

**Missing reports → routed to Sentry:**
- `preferenceService.ts` — captured `err` on all 5 catches; Firestore-backed preference ops now surface in Sentry instead of vanishing into winston.
- `firebaseService.ts` — 4 `onSnapshot` listener errors now report (badGroupReports, guildRefresh, channelPlayerRefresh, channelRemoved).
- `main.ts` — top-level listener catches (badGroup, guildRefresh, channelPlayerRefresh) and the 5 GitHub-issue submission catches (with kind/source/errorType tags). Role-sync-after-save failure escalated from `logger.warn` to `reportError`.
- `WheelsView.tsx` — `.catch` added on three fire-and-forget service calls that were inconsistent with the same calls elsewhere in the file.

**Noisy reports → suppressed or filtered:**
- `firestoreService.ts` — listener errors only report on first failure (was up to 5× amplification per network blip). \"Invalid guild ID\" demoted to `console.warn` (same shape as the #496 fix — URL-derived precondition isn't an error).
- `useCharacterLookup.ts` — filter expected callable codes (`functions/not-found`, `invalid-argument`, `failed-precondition`) so user typos stop firing Sentry events.
- `raiderioService.ts` — filter `AbortError`/`TypeError` network conditions; demo-only path was producing noise from contributor offline runs.
- `useDungeonSuggestions.ts` — aggregate Raider.io batch failures; report only on full-batch failure rather than per-character.

**Overly broad try/catch → tightened or removed:**
- `firestoreService.ts` — narrowed `parseExistingRounds`/`restoreGroupHistory` try to just the `WoWGroup.fromDict` map. The wrapper was hiding validation bugs as normal lifecycle.
- `commands/groups.ts` — dropped inner try/catch in `wheel`, `activity`, and `badgroup`. The `InteractionCreate` wrapper in `main.ts` already reports to Sentry with command/guild tags and replies generically; the inner catches were swallowing errors before that path could see them. Inner `createInvite` catch kept with a scoped `reportError` since it's a known-recoverable subpath.
- `groupsCommand.test.ts` — two tests updated to verify errors now propagate to the caller instead of being caught and logged inline.

## Test plan
- [x] `./scripts/verify-ts.sh` (lint + typecheck + 269 bot tests) — passes
- [x] `./scripts/verify-activity.sh` (typecheck + build + Playwright suite) — passes (one snapshot flake on `Results with highlighted group`, confirmed unrelated by re-run on a different snapshot)
- [ ] After merge + deploy, watch Sentry for net-positive signal: existing alerts (`MYTHIC-PLUS-DISCORD-BOT-1` resolved, `useCharacterLookup` typos / `firestoreService` listener-amplification) should drop, and any genuine bot-side Firestore/GitHub failures will start showing up

🤖 Generated with [Claude Code](https://claude.com/claude-code)