### PR TITLE
fix(activity): proxy raider.io dungeon icons through Discord activity proxy

### DIFF
--- a/activity/src/components/DungeonSuggestions.tsx
+++ b/activity/src/components/DungeonSuggestions.tsx
@@ -1,5 +1,6 @@
 import { useId } from 'react';
 import type { DungeonSuggestion, DungeonSuggestionsStatus } from '../lib/dungeonSuggestions';
+import { remapImageUrl } from '../discordSdk';
 import { KeyLevelSelect } from './KeyLevelSelect';
 
 interface DungeonSuggestionsProps {
@@ -104,13 +105,14 @@ interface DungeonRowProps {
 }
 
 function DungeonRow({ suggestion, rank }: DungeonRowProps) {
+  const proxiedIconUrl = remapImageUrl(suggestion.iconUrl);
   return (
     <li className="dungeon-suggestion-row">
       <span className="dungeon-suggestion-row__rank">{rank}</span>
-      {suggestion.iconUrl ? (
+      {proxiedIconUrl ? (
         <img
           className="dungeon-suggestion-row__icon"
-          src={suggestion.iconUrl}
+          src={proxiedIconUrl}
           alt=""
           aria-hidden="true"
           loading="lazy"

--- a/activity/src/discordSdk.ts
+++ b/activity/src/discordSdk.ts
@@ -28,8 +28,14 @@ try {
   _isEmbedded = true;
 }
 
-const IMAGE_PROXY_PREFIX = '/blizzard-renders';
-const IMAGE_PROXY_TARGET = 'render.worldofwarcraft.com';
+// Hosts whose images are loaded via <img src>. They need both a patchUrlMappings
+// entry (so the SDK whitelists them) AND a Developer Portal URL mapping.
+const IMAGE_HOST_MAPPINGS: { prefix: string; target: string }[] = [
+  // Battle.net character renders (profile pictures)
+  { prefix: '/blizzard-renders', target: 'render.worldofwarcraft.com' },
+  // Raider.io dungeon icons
+  { prefix: '/raiderio-cdn', target: 'cdn.raiderio.net' },
+];
 
 if (_isEmbedded) {
   const mappings: { prefix: string; target: string }[] = [
@@ -37,8 +43,7 @@ if (_isEmbedded) {
     // Firebase Auth endpoints needed for anonymous sign-in
     { prefix: '/auth', target: 'identitytoolkit.googleapis.com' },
     { prefix: '/authtoken', target: 'securetoken.googleapis.com' },
-    // Battle.net character renders (profile pictures)
-    { prefix: IMAGE_PROXY_PREFIX, target: IMAGE_PROXY_TARGET },
+    ...IMAGE_HOST_MAPPINGS,
     // Raider.io character search + profile lookup
     { prefix: '/raiderio', target: 'raider.io' },
   ];
@@ -61,8 +66,9 @@ export function remapImageUrl(url: string | null | undefined): string | null {
   if (!url || !_isEmbedded) return url || null;
   try {
     const parsed = new URL(url);
-    if (parsed.hostname === IMAGE_PROXY_TARGET) {
-      return `${IMAGE_PROXY_PREFIX}${parsed.pathname}${parsed.search}${parsed.hash}`;
+    const mapping = IMAGE_HOST_MAPPINGS.find(m => m.target === parsed.hostname);
+    if (mapping) {
+      return `${mapping.prefix}${parsed.pathname}${parsed.search}${parsed.hash}`;
     }
     return url;
   } catch {


### PR DESCRIPTION
## Summary
- Dungeon icons from `cdn.raiderio.net` weren't loading in the Discord activity. The host wasn't in `patchUrlMappings`, and `<img src>` requests bypass the SDK's fetch patching anyway, so `remapImageUrl` also wasn't being applied to `suggestion.iconUrl`.
- Add `cdn.raiderio.net` → `/raiderio-cdn` to the proxy mapping list and refactor `remapImageUrl` to look up image hosts dynamically (so future image hosts only need one entry).
- Pass `suggestion.iconUrl` through `remapImageUrl` in `DungeonSuggestions`.

## Follow-up (manual)
- The matching prefix → target mapping must be added in the Discord Developer Portal (Activities → URL Mappings) before this takes effect in production.

## Test plan
- [x] `npm -w activity run typecheck`
- [ ] After Developer Portal mapping is added, verify dungeon icons load in the deployed activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)