### PR TITLE
fix: capture spin-input players and prior rounds in bad-group reports

### DIFF
--- a/activity/src/services/firestoreService.ts
+++ b/activity/src/services/firestoreService.ts
@@ -1,4 +1,4 @@
-import { doc, collection, addDoc, onSnapshot, updateDoc, setDoc, serverTimestamp, arrayUnion, arrayRemove, runTransaction } from 'firebase/firestore';
+import { doc, collection, addDoc, getDoc, onSnapshot, updateDoc, setDoc, serverTimestamp, arrayUnion, arrayRemove, runTransaction } from 'firebase/firestore';
 import { db } from '../firebase';
 import { GuildData, ChannelData } from '../types';
 import { useAppStore } from '../store/store';
@@ -339,10 +339,25 @@ class FirestoreSessionService implements SessionService {
     });
     const players = playersFromGroups.length > 0 ? playersFromGroups : channelData.players;
 
+    // Read fresh guild history rather than trusting the cached `guildData`,
+    // which can lag the spin's own `setDoc` if the user clicks Report before
+    // the onSnapshot listener has caught up. Falls back to the cached value
+    // on read failure so a transient network blip still produces a report
+    // (without history) instead of dropping it entirely.
+    let freshGuildData = guildData;
+    if (channelData.guildId) {
+      try {
+        const snap = await getDoc(doc(db, 'guilds', channelData.guildId));
+        if (snap.exists()) freshGuildData = snap.data() as GuildData;
+      } catch (err) {
+        reportError(err, { tag: 'firestoreService.reportBadGroup.getGuildDoc' });
+      }
+    }
+
     // Prior rounds = persisted group history minus the round being reported.
     // The algorithm's pair-history scoring depends on these, so omitting them
     // makes "shouldn't have grouped me with X again" complaints undebuggable.
-    const allRounds = parseExistingRounds(guildData, todayPST());
+    const allRounds = parseExistingRounds(freshGuildData, todayPST());
     const priorRounds = allRounds.slice(0, Math.max(0, allRounds.length - 1));
 
     await addDoc(collection(db, 'badGroupReports'), {

--- a/activity/src/services/firestoreService.ts
+++ b/activity/src/services/firestoreService.ts
@@ -323,8 +323,27 @@ class FirestoreSessionService implements SessionService {
   }
 
   async reportBadGroup(title: string, description: string): Promise<void> {
-    const { channelData, currentPlayerName, currentPlayerId } = useAppStore.getState();
+    const { channelData, guildData, currentPlayerName, currentPlayerId } = useAppStore.getState();
     if (!channelData) return;
+
+    // Use the players actually in the spin output, not channelData.players —
+    // voice-channel membership drifts (people leave to start the dungeon)
+    // between spin and report, which would otherwise silently truncate the
+    // input list and make the report unreproducible.
+    const playersFromGroups = channelData.groups.flatMap((g) => {
+      const members: typeof channelData.players = [];
+      if (g.tank) members.push(g.tank);
+      if (g.healer) members.push(g.healer);
+      if (g.dps) members.push(...g.dps);
+      return members;
+    });
+    const players = playersFromGroups.length > 0 ? playersFromGroups : channelData.players;
+
+    // Prior rounds = persisted group history minus the round being reported.
+    // The algorithm's pair-history scoring depends on these, so omitting them
+    // makes "shouldn't have grouped me with X again" complaints undebuggable.
+    const allRounds = parseExistingRounds(guildData, todayPST());
+    const priorRounds = allRounds.slice(0, Math.max(0, allRounds.length - 1));
 
     await addDoc(collection(db, 'badGroupReports'), {
       title,
@@ -332,8 +351,9 @@ class FirestoreSessionService implements SessionService {
       reporterName: currentPlayerName || 'Unknown',
       reporterId: currentPlayerId || 'Unknown',
       guildId: channelData.guildId || null,
-      players: channelData.players,
+      players,
       groups: channelData.groups,
+      priorRounds: encodeGroupHistoryRounds(priorRounds),
       createdAt: serverTimestamp(),
     });
   }

--- a/packages/bot/src/core/issues.ts
+++ b/packages/bot/src/core/issues.ts
@@ -196,6 +196,12 @@ export interface BadGroupReportData {
   description: string;
   players: { toTestString(): string }[];
   groups: { toTestString(): string }[];
+  /**
+   * Earlier rounds the algorithm had in pair-history when this round ran.
+   * Required to debug "shouldn't have grouped me with X again" complaints,
+   * since the per-day pair-count scoring depends on prior pairings.
+   */
+  priorRounds?: { toTestString(): string }[][];
 }
 
 export async function reportBadGroup(
@@ -208,9 +214,16 @@ export async function reportBadGroup(
   const formattedTitle = `[Bad Group] ${safeTitle}`;
   const versionStr = getVersionString();
 
-  const reproInfo =
+  let reproInfo =
     `**Input Players:**\n\`\`\`python\n[${data.players.map((p) => p.toTestString()).join(', ')}]\n\`\`\`\n` +
     `**Resulting Groups:**\n\`\`\`python\n[${data.groups.map((g) => g.toTestString()).join(', ')}]\n\`\`\`\n`;
+
+  if (data.priorRounds && data.priorRounds.length > 0) {
+    const renderedRounds = data.priorRounds
+      .map((round, i) => `Round ${i + 1}: [${round.map((g) => g.toTestString()).join(', ')}]`)
+      .join('\n');
+    reproInfo += `**Prior Rounds:**\n\`\`\`python\n${renderedRounds}\n\`\`\`\n`;
+  }
 
   let body =
     `**Reporter:** ${safeReporterName} (\`${sanitizeForGithub(String(data.reporterId))}\`)\n` +

--- a/packages/bot/src/main.ts
+++ b/packages/bot/src/main.ts
@@ -32,7 +32,7 @@ import { DebugHandler } from './commands/debug.js';
 import { onReady } from './events/ready.js';
 import { getWowName, getPlayerList, type DiscordMember } from './core/utils.js';
 import { FirebaseService, DELETE_FIELD } from './core/firebaseService.js';
-import { WoWPlayer, WoWGroup, STATIC_AFFIXES } from '@mythicplus/shared';
+import { WoWPlayer, WoWGroup, STATIC_AFFIXES, decodeGroupHistoryRounds } from '@mythicplus/shared';
 import type { AffixDisplay } from '@mythicplus/shared';
 import { reportBadGroup, submitGithubIssueModal, GitHubError } from './core/issues.js';
 import type { GitHubIssueResponse } from './core/issues.js';
@@ -488,6 +488,14 @@ async function main() {
         const players = playersData.map((p) => WoWPlayer.fromDict(p));
         const groups = groupsData.map((g) => WoWGroup.fromDict(g));
 
+        // Prior rounds use the same wrapped wire shape as guild groupHistory
+        // (Firestore rejects nested arrays). Defensively tolerate missing /
+        // malformed history so a bad doc still files an issue rather than
+        // dropping the report.
+        const priorRoundsRaw = Array.isArray(data.priorRounds) ? data.priorRounds : [];
+        const priorRounds = decodeGroupHistoryRounds(priorRoundsRaw)
+          .map((round) => round.map((g) => WoWGroup.fromDict(g)));
+
         const issue = await reportBadGroup({
           reporterName: String(data.reporterName ?? 'Unknown'),
           reporterId: String(data.reporterId ?? 'Unknown'),
@@ -495,6 +503,7 @@ async function main() {
           description: String(data.description ?? ''),
           players,
           groups,
+          priorRounds,
         });
 
         logger.info(`Bad group report processed: ${issue.html_url}`);

--- a/packages/bot/tests/badgroup.test.ts
+++ b/packages/bot/tests/badgroup.test.ts
@@ -61,4 +61,49 @@ describe('reportBadGroup', () => {
       '[`abc1234`](https://github.com/owner/repo/commit/abc123456)';
     expect(body.body).toContain(`**Version:** ${expectedVersion}`);
   });
+
+  it('renders prior rounds when supplied', async () => {
+    const priorTank = WoWPlayer.create('PriorTank', ['Tank']);
+    const priorHealer = WoWPlayer.create('PriorHealer', ['Healer']);
+    const priorDps1 = WoWPlayer.create('PriorDps1', ['Melee']);
+    const priorDps2 = WoWPlayer.create('PriorDps2', ['Ranged']);
+    const priorDps3 = WoWPlayer.create('PriorDps3', ['Melee']);
+    const priorRound1 = [
+      new WoWGroup(priorTank, priorHealer, [priorDps1, priorDps2, priorDps3]),
+    ];
+
+    await reportBadGroup({
+      reporterName: 'TestUser',
+      reporterId: '12345',
+      title: 'Repeat pairing',
+      description: 'Got grouped with same person twice',
+      players,
+      groups: [group],
+      priorRounds: [priorRound1],
+    });
+
+    const fetchCall = vi.mocked(global.fetch).mock.calls[0];
+    const body = JSON.parse(fetchCall[1]!.body as string) as { body: string };
+
+    expect(body.body).toContain('**Prior Rounds:**');
+    expect(body.body).toContain('PriorTank');
+    expect(body.body).toContain('PriorHealer');
+  });
+
+  it('omits prior rounds section when not supplied or empty', async () => {
+    await reportBadGroup({
+      reporterName: 'TestUser',
+      reporterId: '12345',
+      title: 'No history',
+      description: 'First round of the night',
+      players,
+      groups: [group],
+      priorRounds: [],
+    });
+
+    const fetchCall = vi.mocked(global.fetch).mock.calls[0];
+    const body = JSON.parse(fetchCall[1]!.body as string) as { body: string };
+
+    expect(body.body).not.toContain('**Prior Rounds:**');
+  });
 });


### PR DESCRIPTION
## Summary
- Fix `firestoreService.reportBadGroup` to derive players from `channelData.groups` (the persisted spin output) instead of `channelData.players` (live voice-channel state, which shrinks as players leave to start the dungeon).
- Include prior round history from `guildData.groupHistory` in the report so pair-history scoring is debuggable for "grouped with X again" complaints.
- Thread `priorRounds` through the bot listener and render a `**Prior Rounds:**` section in the GitHub issue body.

Surfaced by #502, where the report had 6 listed input players but 15 in the resulting groups, making the bug unreproducible.

## Test plan
- [x] New unit tests in `packages/bot/tests/badgroup.test.ts` cover prior-round rendering and the empty-history fallback.
- [x] `./scripts/verify-ts.sh` passes (lint + typecheck + 271 tests).
- [x] `activity` typecheck + Vite build + Storybook build pass.
- [ ] Verify manually after deploy that a fresh bad-group report contains the full spin participant list and prior rounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)