### PR TITLE
fix(activity): silence false-positive Sentry alerts from channel doc watchdog

### DIFF
--- a/activity/src/lib/sentry.ts
+++ b/activity/src/lib/sentry.ts
@@ -41,6 +41,12 @@ export function initSentry(): void {
     release: typeof __COMMIT_HASH__ !== 'undefined' ? __COMMIT_HASH__ : undefined,
     // Keep the payload small — we care about errors, not performance traces.
     tracesSampleRate: 0,
+    // Drop benign cancellations bubbled up by Firebase/Discord SDKs through
+    // `onunhandledrejection` as bare strings — they have no stacktrace and
+    // no actionable signal.
+    ignoreErrors: [
+      /Non-Error promise rejection captured with value: cancelled/,
+    ],
     // Anonymous correlation only. NEVER pass Discord user IDs here.
     initialScope: {
       user: { id: getAnonymousId() },

--- a/activity/src/services/firestoreService.ts
+++ b/activity/src/services/firestoreService.ts
@@ -155,15 +155,18 @@ class FirestoreSessionService implements SessionService {
         // The listener fires `exists()=false` during normal lifecycle —
         // before `selectChannel` finishes creating the doc, or before the bot
         // has written it on activity launch. Only escalate if the doc is
-        // still missing after a grace period (stale URL, deleted doc, or a
-        // bot-side write failure that would otherwise leave the user stuck
-        // on "Loading...").
+        // still missing after a grace period AND the user is on a view that
+        // depends on channel data; on home/channels the doc may legitimately
+        // not exist yet (URL/Discord SDK sets currentChannelId before the
+        // user has selected a channel, which is what bootstraps the doc).
         if (this.channelMissingTimer === null) {
           this.channelMissingTimer = setTimeout(() => {
             this.channelMissingTimer = null;
+            const view = useAppStore.getState().currentView;
+            if (view === 'home' || view === 'channels') return;
             reportError(
               new Error(`No doc at channels/${channelId} after ${CHANNEL_DOC_MISSING_GRACE_MS}ms`),
-              { tag: 'firestoreService.channelDocMissing', extra: { channelId } },
+              { tag: 'firestoreService.channelDocMissing', extra: { channelId, view } },
             );
           }, CHANNEL_DOC_MISSING_GRACE_MS);
         }


### PR DESCRIPTION
## Summary

Two telemetry-only fixes for the unresolved Sentry issues on this project:

- **`MYTHIC-PLUS-DISCORD-BOT-3`** (5 events / 5 users / same channel ID): the `channelDocMissing` watchdog in `firestoreService.ts` was firing whenever `currentChannelId` was set without a backing Firestore doc. That happens legitimately when a user lands on the channels view via a URL param or Discord SDK launch before they've selected/bootstrapped a channel — `selectChannel` is what creates the doc, and the bot only auto-creates it on `/activity`. Suppress the alert in `home`/`channels` views; `lobby`/`wheels`/`results`/`identity`/`setup` still fire so genuine stuck-state regressions are still caught. Added `view` to the extra payload for future diagnosis.
- **`MYTHIC-PLUS-DISCORD-BOT-2`** (1 event in 7 days, no stack): bare-string `'cancelled'` rejection bubbling up from a Firebase / Discord SDK lifecycle event through `onunhandledrejection`. Drop it via Sentry `ignoreErrors`.

Neither change affects rendering, so visual snapshots should be unaffected.

## Test plan

- [x] `npm -w activity run typecheck` clean
- [x] `eslint` clean on both files
- [ ] CI green (Lint / Build / Test)
- [ ] After deploy, watch Sentry for new occurrences of `channelDocMissing` and `cancelled` rejections — expect counts to drop to ~0

🤖 Generated with [Claude Code](https://claude.com/claude-code)