### PR TITLE
fix(shared): minimize repeat teammates in group formation (#512)

### DIFF
--- a/packages/bot/tests/parallelGroupCreator.test.ts
+++ b/packages/bot/tests/parallelGroupCreator.test.ts
@@ -403,4 +403,105 @@ describe('GroupCreator', () => {
     expect(dpsNames).not.toContain('DPS1');
     expect(dpsNames).toContain('DPS6');
   });
+
+  it('reaches the global minimum pair-overlap on the issue #512 input', () => {
+    // Reproduction of issue #512. With the captured prior rounds, the greedy
+    // fillRemainingDps pass leaves the last-filled group with leftover DPS
+    // and produces total pair-overlap up to 14 across runs (avg ~10.5). A
+    // brute-force search of valid 3-group partitions for this input shows
+    // the global minimum total pair-overlap is 10. The post-processing
+    // diversifyGroups step in createMythicPlusGroups should reach that
+    // minimum on every spin so a player like Tyt isn't stranded with two
+    // already-seen teammates while a strictly better assignment exists.
+    for (let trial = 0; trial < 25; trial++) {
+      clear();
+
+      const Gazzi = WoWPlayer.create('Gazzi (Nikki)', ['Tank', 'Brez']);
+      const Sorovar = WoWPlayer.create('Sorovar (Jeremy)', ['Healer', 'Ranged Offspec']);
+      const Poppy = WoWPlayer.create('Poppybrosjr (Steve)', ['Ranged', 'Lust']);
+      const JohnG = WoWPlayer.create('John G', ['Melee', 'Tank Offspec', 'Brez']);
+      const Marti = WoWPlayer.create('Martichoux (Erik)', ['Ranged', 'Ranged Offspec', 'Lust']);
+      const Temma = WoWPlayer.create('Temma (Ben)', ['Tank', 'Melee Offspec', 'Brez']);
+      const Quill = WoWPlayer.create('Quill (Josh)', [
+        'Healer',
+        'Tank Offspec',
+        'Ranged Offspec',
+        'Melee Offspec',
+        'Brez',
+      ]);
+      const Volk = WoWPlayer.create('Volkareth (Graham)', ['Ranged', 'Lust']);
+      const Alch = WoWPlayer.create('Alchemy (Yamyam)', ['Ranged', 'Brez']);
+      const Mickey = WoWPlayer.create('Mickey (rook (AJ))', ['Melee']);
+      const Drach = WoWPlayer.create('Drachlyn (Evan)', ['Tank', 'Brez']);
+      const Cyonoc = WoWPlayer.create('Cyonoc (Kyle)', ['Healer', 'Healer Offspec', 'Brez']);
+      const Tyt = WoWPlayer.create('Tytaniormu (Tyler)', ['Ranged', 'Lust']);
+      const Blue = WoWPlayer.create('Blueshift (Bevan)', ['Ranged']);
+      const jim = WoWPlayer.create('jim (Stink)', ['Melee', 'Tank Offspec']);
+      const Raxef = WoWPlayer.create('Raxef', ['Melee']);
+
+      const mkGroup = (
+        tank: WoWPlayer | null,
+        healer: WoWPlayer | null,
+        dps: WoWPlayer[],
+      ): WoWGroup => {
+        const g = new WoWGroup();
+        g.tank = tank;
+        g.healer = healer;
+        g.dps = [...dps];
+        return g;
+      };
+
+      const r1 = [
+        mkGroup(Gazzi, Cyonoc, [Volk, Mickey, JohnG]),
+        mkGroup(Drach, Quill, [Poppy, jim, Alch]),
+        mkGroup(Temma, Sorovar, [Blue, Tyt]),
+      ];
+      const r2 = [
+        mkGroup(Drach, Sorovar, [Volk, Marti, Raxef]),
+        mkGroup(Gazzi, Quill, [Tyt, jim, Mickey]),
+        mkGroup(Temma, Cyonoc, [Poppy, Blue, Alch]),
+      ];
+
+      setGroupHistory([r1, r2]);
+
+      const players = [
+        Gazzi, Sorovar, Poppy, JohnG, Marti,
+        Temma, Quill, Volk, Alch, Mickey,
+        Drach, Cyonoc, Tyt, Blue, jim,
+      ];
+      const groups = createMythicPlusGroups(players);
+      expect(groups.length).toBe(3);
+
+      const pairCount = new Map<string, number>();
+      for (const round of [r1, r2]) {
+        for (const grp of round) {
+          const ms = grp.players;
+          for (let i = 0; i < ms.length; i++) {
+            for (let j = i + 1; j < ms.length; j++) {
+              const a = ms[i].name, b = ms[j].name;
+              const key = a < b ? `${a}|${b}` : `${b}|${a}`;
+              pairCount.set(key, (pairCount.get(key) ?? 0) + 1);
+            }
+          }
+        }
+      }
+
+      let totalOverlap = 0;
+      for (const group of groups) {
+        const ms = group.players;
+        for (let i = 0; i < ms.length; i++) {
+          for (let j = i + 1; j < ms.length; j++) {
+            const a = ms[i].name, b = ms[j].name;
+            const key = a < b ? `${a}|${b}` : `${b}|${a}`;
+            totalOverlap += pairCount.get(key) ?? 0;
+          }
+        }
+      }
+
+      expect(
+        totalOverlap,
+        `total pair overlap was ${totalOverlap} on trial ${trial}, expected the proven global minimum of 10`,
+      ).toBe(10);
+    }
+  });
 });

--- a/packages/shared/src/parallelGroupCreator.ts
+++ b/packages/shared/src/parallelGroupCreator.ts
@@ -37,6 +37,276 @@ function removeFromList(list: WoWPlayer[], player: WoWPlayer): void {
 }
 
 /**
+ * Canonical key for an unordered name pair, so `pairCounts.get(pairKey(a, b))`
+ * yields the same value regardless of argument order. Mirrored verbatim by
+ * the Lua addon's pair-count map — keep the format byte-for-byte identical.
+ */
+function pairKey(a: string, b: string): string {
+  return a < b ? a + '|' + b : b + '|' + a;
+}
+
+/**
+ * Slot in a `WoWGroup` (independent of `Role` from types.ts: there ranged/melee
+ * are distinct, here both fall under `'dps'`). Tagged so `dpsIdx` is only
+ * present where it's meaningful.
+ */
+type SlotInfo =
+  | { slot: 'tank' }
+  | { slot: 'healer' }
+  | { slot: 'dps'; dpsIdx: number };
+
+/** Identify which slot a player occupies in a group, or null if absent. */
+function findSlot(group: WoWGroup, player: WoWPlayer): SlotInfo | null {
+  if (group.tank?.equals(player)) return { slot: 'tank' };
+  if (group.healer?.equals(player)) return { slot: 'healer' };
+  const dpsIdx = group.dps.findIndex((p) => p.equals(player));
+  if (dpsIdx !== -1) return { slot: 'dps', dpsIdx };
+  return null;
+}
+
+/** Mutate `group` in place, placing `player` at the slot described by `info`. */
+function setSlot(group: WoWGroup, info: SlotInfo, player: WoWPlayer): void {
+  if (info.slot === 'tank') group.tank = player;
+  else if (info.slot === 'healer') group.healer = player;
+  else group.dps[info.dpsIdx] = player;
+}
+
+/**
+ * Whether `player` is a legal occupant of `slot`. Mirrors the constraints the
+ * fill phases impose: tanks cannot be healer-mains, tank slot needs a tank-
+ * capable player, healer slot needs a healer-capable player, DPS accepts any
+ * player with a DPS spec or offspec.
+ */
+function canFillSlot(player: WoWPlayer, slot: SlotInfo['slot']): boolean {
+  if (slot === 'tank') return (player.tankMain || player.offtank) && !player.healerMain;
+  if (slot === 'healer') return player.healerMain || player.offhealer;
+  return player.dpsMain || player.offdps;
+}
+
+/**
+ * Lexicographic score for a group set:
+ *   - `maxPerPlayer`: worst-case count of repeat-teammates any single player has
+ *   - `total`: sum of pair-counts for every unique pair across all groups
+ *
+ * Smaller is better on both axes; `maxPerPlayer` dominates because the user-
+ * facing complaint is "*I* keep getting grouped with X again", not "the
+ * algorithm-wide repeat sum is high".
+ */
+function scoreGroups(
+  groups: readonly WoWGroup[],
+  pairCounts: Map<string, number>,
+): { maxPerPlayer: number; total: number } {
+  let maxPerPlayer = 0;
+  let perPlayerSum = 0;
+  for (const g of groups) {
+    const ms = g.players;
+    for (let i = 0; i < ms.length; i++) {
+      let perPlayer = 0;
+      for (let j = 0; j < ms.length; j++) {
+        if (i === j) continue;
+        perPlayer += pairCounts.get(pairKey(ms[i].name, ms[j].name)) ?? 0;
+      }
+      if (perPlayer > maxPerPlayer) maxPerPlayer = perPlayer;
+      perPlayerSum += perPlayer;
+    }
+  }
+  // Each unique pair is summed twice across the players' perPlayer counts.
+  return { maxPerPlayer, total: perPlayerSum / 2 };
+}
+
+function isBetterScore(
+  candidate: { maxPerPlayer: number; total: number },
+  current: { maxPerPlayer: number; total: number },
+): boolean {
+  if (candidate.maxPerPlayer !== current.maxPerPlayer) {
+    return candidate.maxPerPlayer < current.maxPerPlayer;
+  }
+  return candidate.total < current.total;
+}
+
+/**
+ * Try every legal pairwise swap; apply the best one if it strictly improves
+ * the lexicographic score. Returns true if a swap was applied.
+ */
+function trySingleSwap(
+  groups: WoWGroup[],
+  pairCounts: Map<string, number>,
+  origBrez: boolean[],
+  origLust: boolean[],
+): boolean {
+  let bestScore = scoreGroups(groups, pairCounts);
+  let bestSwap:
+    | { gi: WoWGroup; gj: WoWGroup; pa: WoWPlayer; sa: SlotInfo; pb: WoWPlayer; sb: SlotInfo }
+    | null = null;
+
+  for (let i = 0; i < groups.length; i++) {
+    for (let j = i + 1; j < groups.length; j++) {
+      const gi = groups[i];
+      const gj = groups[j];
+      const playersI = gi.players;
+      const playersJ = gj.players;
+      for (const pa of playersI) {
+        const sa = findSlot(gi, pa);
+        if (!sa) continue;
+        for (const pb of playersJ) {
+          const sb = findSlot(gj, pb);
+          if (!sb) continue;
+          if (!canFillSlot(pa, sb.slot) || !canFillSlot(pb, sa.slot)) continue;
+
+          setSlot(gi, sa, pb);
+          setSlot(gj, sb, pa);
+          const utilityOk = (!origBrez[i] || gi.hasBrez)
+            && (!origLust[i] || gi.hasLust)
+            && (!origBrez[j] || gj.hasBrez)
+            && (!origLust[j] || gj.hasLust);
+          if (utilityOk) {
+            const candidate = scoreGroups(groups, pairCounts);
+            if (isBetterScore(candidate, bestScore)) {
+              bestScore = candidate;
+              bestSwap = { gi, gj, pa, sa, pb, sb };
+            }
+          }
+          setSlot(gi, sa, pa);
+          setSlot(gj, sb, pb);
+        }
+      }
+    }
+  }
+
+  if (!bestSwap) return false;
+  setSlot(bestSwap.gi, bestSwap.sa, bestSwap.pb);
+  setSlot(bestSwap.gj, bestSwap.sb, bestSwap.pa);
+  return true;
+}
+
+/**
+ * Escape single-swap local minima by rotating one player between three
+ * groups (gi → gj → gk → gi). Some optimal assignments — particularly when
+ * tank/healer placements are interdependent — are unreachable via any
+ * single 2-swap because each individual swap looks worse than the current
+ * state, but the composite 3-cycle improves it. Returns true if a cycle
+ * was applied.
+ */
+function tryThreeCycle(
+  groups: WoWGroup[],
+  pairCounts: Map<string, number>,
+  origBrez: boolean[],
+  origLust: boolean[],
+): boolean {
+  if (groups.length < 3) return false;
+
+  let bestScore = scoreGroups(groups, pairCounts);
+  let bestCycle:
+    | {
+      gi: WoWGroup; pi: WoWPlayer; si: SlotInfo;
+      gj: WoWGroup; pj: WoWPlayer; sj: SlotInfo;
+      gk: WoWGroup; pk: WoWPlayer; sk: SlotInfo;
+    }
+    | null = null;
+
+  for (let i = 0; i < groups.length; i++) {
+    for (let j = 0; j < groups.length; j++) {
+      if (j === i) continue;
+      for (let k = 0; k < groups.length; k++) {
+        if (k === i || k === j) continue;
+        const gi = groups[i];
+        const gj = groups[j];
+        const gk = groups[k];
+        const playersI = gi.players;
+        const playersJ = gj.players;
+        const playersK = gk.players;
+        for (const pi of playersI) {
+          const si = findSlot(gi, pi);
+          if (!si) continue;
+          for (const pj of playersJ) {
+            const sj = findSlot(gj, pj);
+            if (!sj) continue;
+            if (!canFillSlot(pi, sj.slot)) continue;
+            for (const pk of playersK) {
+              const sk = findSlot(gk, pk);
+              if (!sk) continue;
+              if (!canFillSlot(pj, sk.slot) || !canFillSlot(pk, si.slot)) continue;
+
+              setSlot(gi, si, pk);
+              setSlot(gj, sj, pi);
+              setSlot(gk, sk, pj);
+              const utilityOk = (!origBrez[i] || gi.hasBrez)
+                && (!origLust[i] || gi.hasLust)
+                && (!origBrez[j] || gj.hasBrez)
+                && (!origLust[j] || gj.hasLust)
+                && (!origBrez[k] || gk.hasBrez)
+                && (!origLust[k] || gk.hasLust);
+              if (utilityOk) {
+                const candidate = scoreGroups(groups, pairCounts);
+                if (isBetterScore(candidate, bestScore)) {
+                  bestScore = candidate;
+                  bestCycle = { gi, pi, si, gj, pj, sj, gk, pk, sk };
+                }
+              }
+              setSlot(gi, si, pi);
+              setSlot(gj, sj, pj);
+              setSlot(gk, sk, pk);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (!bestCycle) return false;
+  setSlot(bestCycle.gi, bestCycle.si, bestCycle.pk);
+  setSlot(bestCycle.gj, bestCycle.sj, bestCycle.pi);
+  setSlot(bestCycle.gk, bestCycle.sk, bestCycle.pj);
+  return true;
+}
+
+/**
+ * Local-search post-processing: swap pairs of players between groups if doing
+ * so lowers the lexicographic `(maxPerPlayer, total)` score. The greedy fill
+ * passes optimize each group as it is built, which strands the last-filled
+ * group with the leftover DPS and can leave one player with 2+ repeat
+ * teammates even though a strictly better assignment exists. This pass cleans
+ * that up without changing role assignments or utility coverage. See issue
+ * #512 for the motivating scenario.
+ *
+ * Two phases run alternately until both quiesce. Single-swap exploration
+ * handles the common cases. A 3-cycle pass escapes local minima that single
+ * swaps can't see — typically when tank or healer placements would all need
+ * to rotate between groups simultaneously to improve the score.
+ *
+ * Constraints preserved:
+ *   - Role compatibility for each slot (tank/healer/DPS slot occupants).
+ *   - No healer-main placed as tank.
+ *   - Brez/lust coverage of any group that originally had it.
+ *   - Group sizes (only same-cardinality slot swaps occur).
+ *
+ * Mirrored in Lua by the MythicPlusWheel addon — keep behavior in sync.
+ */
+function diversifyGroups(groups: WoWGroup[], pairCounts: Map<string, number>): void {
+  if (pairCounts.size === 0) return;
+
+  const completeGroups = groups.filter((g) => g.isComplete);
+  if (completeGroups.length < 2) return;
+
+  const origBrez = completeGroups.map((g) => g.hasBrez);
+  const origLust = completeGroups.map((g) => g.hasLust);
+
+  // Outer loop bounded so a hostile pair-count map can't make this run away;
+  // each phase already converges in O(complete-groups) iterations in practice.
+  const maxOuter = completeGroups.length * 4;
+  for (let outer = 0; outer < maxOuter; outer++) {
+    let progress = false;
+    while (trySingleSwap(completeGroups, pairCounts, origBrez, origLust)) {
+      progress = true;
+    }
+    if (tryThreeCycle(completeGroups, pairCounts, origBrez, origLust)) {
+      progress = true;
+    }
+    if (!progress) return;
+  }
+}
+
+/**
  * Form balanced Mythic+ groups from a player pool. Used by both the bot
  * (Discord-only `/wheel`) and the frontend (Activity spin), and mirrored in
  * Lua by the MythicPlusWheel addon — keep behavior in sync if you change it.
@@ -74,8 +344,7 @@ export function createMythicPlusGroups(
       const members = group.players;
       for (let i = 0; i < members.length; i++) {
         for (let j = i + 1; j < members.length; j++) {
-          const [n1, n2] = [members[i].name, members[j].name];
-          const key = n1 < n2 ? n1 + '|' + n2 : n2 + '|' + n1;
+          const key = pairKey(members[i].name, members[j].name);
           pairCounts.set(key, (pairCounts.get(key) ?? 0) + 1);
         }
       }
@@ -169,8 +438,7 @@ export function createMythicPlusGroups(
       // Score = total times this player has been grouped with current teammates
       let score = 0;
       for (const teammate of teammates) {
-        const key = player.name < teammate.name ? player.name + '|' + teammate.name : teammate.name + '|' + player.name;
-        score += pairCounts.get(key) ?? 0;
+        score += pairCounts.get(pairKey(player.name, teammate.name)) ?? 0;
       }
 
       if (score < bestScore) {
@@ -352,6 +620,8 @@ export function createMythicPlusGroups(
   fillRanged();
   fillRemainingDps();
   handleRemainders();
+
+  diversifyGroups(groups, pairCounts);
 
   groupHistory.set(guildId, [...rounds, groups]);
   return groups;

--- a/packages/shared/src/parallelGroupCreator.ts
+++ b/packages/shared/src/parallelGroupCreator.ts
@@ -204,11 +204,13 @@ function tryThreeCycle(
     }
     | null = null;
 
+  // For any triple of groups (A, B, C) there are 6 ordered iterations but only
+  // 2 distinct cycles: (A→B→C→A) and (A→C→B→A). Constraining j > i and k > i
+  // (with k != j) hits both per triple while skipping the 4 duplicate rotations.
   for (let i = 0; i < groups.length; i++) {
-    for (let j = 0; j < groups.length; j++) {
-      if (j === i) continue;
-      for (let k = 0; k < groups.length; k++) {
-        if (k === i || k === j) continue;
+    for (let j = i + 1; j < groups.length; j++) {
+      for (let k = i + 1; k < groups.length; k++) {
+        if (k === j) continue;
         const gi = groups[i];
         const gj = groups[j];
         const gk = groups[k];


### PR DESCRIPTION
## Summary
- Issue #512 reported "exactly the same group" forming across rounds. The captured prior rounds don't actually have a literal exact-group repeat, but the algorithm produces groups where one player ends up with multiple already-seen teammates (e.g. Tyt was placed with Blue (R1) and jim (R2) again, even though a strictly better assignment exists).
- The greedy `fillRemainingDps` pass minimizes pair-overlap within each group as it builds up, which strands the last-filled group with whatever DPS the earlier groups didn't want. This makes per-group local-optimal but globally suboptimal.
- Add a `diversifyGroups` post-processing step that lowers a lexicographic `(maxPerPlayer, total)` pair-overlap score via legal swaps, with a 3-cycle escape for single-swap local minima.

## Constraints preserved
- Role compatibility for each slot (tank/healer/DPS slot occupants)
- No healer-main placed as tank
- Brez/lust coverage of any group that originally had it
- Group sizes (only same-cardinality slot swaps occur)

## Empirical results
On the issue #512 reproduction (15 players, 2 prior rounds), 2000 trials:
- **Before:** total pair-overlap min=10, avg≈10.5, max=14
- **After:** total pair-overlap exactly 10 every run (the proven global minimum for this input)

The mathematical lower bound on `maxPerPlayer` for this input is 2 — there are four doubled prior pairs and pigeonhole forces at least one player into 2 repeat teammates regardless of partition. The new optimizer hits both that 2-bound and the 10-total bound consistently.

## Lua sibling
The MythicPlusWheel addon (separate repo) reimplements this algorithm in Lua and needs the same `diversifyGroups` pass for the in-game wheel to stay in sync. Comment notes this on the new function.

## Test plan
- [x] New regression test in `parallelGroupCreator.test.ts` replays the issue #512 prior rounds and asserts total pair-overlap = 10 across 25 trials.
- [x] `./scripts/verify-ts.sh` passes (lint + typecheck + 272 tests).
- [x] `npm run typecheck` and `npm run build` pass for the activity frontend.
- [ ] Manually verify after deploy that fresh spins on real guilds produce more diverse group compositions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)