### PR TITLE
chore: drop unused export modifiers on internal-only types

### DIFF
--- a/activity/src/components/PlayerChip.tsx
+++ b/activity/src/components/PlayerChip.tsx
@@ -17,7 +17,7 @@ const NotReadyIcon = () => (
   </svg>
 );
 
-export interface PlayerChipProps {
+interface PlayerChipProps {
   name: string;
   roleKey: string;
   roleLabel: string;

--- a/activity/src/discordSdk.ts
+++ b/activity/src/discordSdk.ts
@@ -1,12 +1,12 @@
 import { DiscordSDK, patchUrlMappings } from '@discord/embedded-app-sdk';
 import { reportError } from './lib/sentry';
 
-export interface DiscordContext {
+interface DiscordContext {
   guildId: string;
   channelId: string | null;
 }
 
-export interface DiscordParticipant {
+interface DiscordParticipant {
   id: string;
   nickname: string | null;
   global_name: string | null;

--- a/activity/src/hooks/useCharacterLookup.ts
+++ b/activity/src/hooks/useCharacterLookup.ts
@@ -21,7 +21,7 @@ function isExpectedLookupError(err: unknown): boolean {
   return typeof code === 'string' && EXPECTED_LOOKUP_CODES.has(code);
 }
 
-export interface CharacterData {
+interface CharacterData {
   name: string;
   realm: string;
   class: CharacterClass | null;

--- a/activity/src/hooks/useMediaQuery.ts
+++ b/activity/src/hooks/useMediaQuery.ts
@@ -1,6 +1,6 @@
 import { useSyncExternalStore } from 'react';
 
-export function useMediaQuery(query: string): boolean {
+function useMediaQuery(query: string): boolean {
   const mql = typeof window !== 'undefined' ? window.matchMedia(query) : null;
 
   return useSyncExternalStore(

--- a/packages/bot/src/commands/general.ts
+++ b/packages/bot/src/commands/general.ts
@@ -12,7 +12,7 @@ export interface VoiceClient {
   disconnect(options?: { force?: boolean }): Promise<void>;
 }
 
-export interface EmbedData {
+interface EmbedData {
   title: string;
   color: number;
   fields: { name: string; value: string; inline?: boolean }[];

--- a/packages/bot/src/core/roleUi.ts
+++ b/packages/bot/src/core/roleUi.ts
@@ -11,7 +11,7 @@ import {
   ROLE_TANK_OFFSPEC,
 } from '@mythicplus/shared';
 
-export type ButtonStyle = 'primary' | 'secondary' | 'success';
+type ButtonStyle = 'primary' | 'secondary' | 'success';
 
 export interface RoleButtonData {
   roleName: string;

--- a/packages/bot/src/core/sentry.ts
+++ b/packages/bot/src/core/sentry.ts
@@ -13,7 +13,7 @@ export function initSentry() {
   });
 }
 
-export interface ReportErrorContext {
+interface ReportErrorContext {
   tags?: Record<string, string | undefined>;
   user?: { id: string; username: string };
   extra?: Record<string, unknown>;

--- a/packages/bot/src/services/sessionService.ts
+++ b/packages/bot/src/services/sessionService.ts
@@ -2,7 +2,7 @@ import { FirebaseService, ARRAY_UNION, ARRAY_REMOVE } from '../core/firebaseServ
 import logger from '../core/logger.js';
 import { getPlayerList, type DiscordMember } from '../core/utils.js';
 
-export interface ActiveChannel {
+interface ActiveChannel {
   docId: string;
   guildId: string;
 }

--- a/packages/functions/src/fetchWeeklyAffixes.ts
+++ b/packages/functions/src/fetchWeeklyAffixes.ts
@@ -5,7 +5,7 @@ import { resolveAffixDisplay, STATIC_AFFIXES, BARGAIN_AFFIXES, type AffixDisplay
 import { enforceRateLimit } from './rateLimit.js';
 import { fetchCurrentSeasonInfo, type SeasonInfo } from './fetchCurrentSeason.js';
 
-export interface AffixDocument {
+interface AffixDocument {
   period: number;
   region: string;
   lastUpdated: FieldValue | Date;

--- a/packages/functions/src/refreshCharacterMedia.ts
+++ b/packages/functions/src/refreshCharacterMedia.ts
@@ -16,15 +16,15 @@ interface LinkedCharacter {
 // Battle.net lookup fails: previously-verified targets get a pass on transient
 // failures, while inGameName-derived targets indicate stale/invalid user input
 // and get their character fields cleared.
-export type TargetSource = 'linkedCharacter' | 'inGameName';
+type TargetSource = 'linkedCharacter' | 'inGameName';
 
-export interface RefreshTarget {
+interface RefreshTarget {
   discordId: string;
   linkedCharacter: LinkedCharacter;
   source: TargetSource;
 }
 
-export interface RefreshSummary {
+interface RefreshSummary {
   total: number;
   refreshed: number;
   skipped: number;
@@ -80,7 +80,7 @@ function hasAnyCharacterField(data: Record<string, unknown>): boolean {
   return CHARACTER_FIELDS_TO_CLEAR.some((f) => data[f] != null);
 }
 
-export interface ClassifiedDocs {
+interface ClassifiedDocs {
   // BN-resolvable. Preferred source: linkedCharacter (server-verified),
   // falling back to parsed inGameName for older docs.
   targets: RefreshTarget[];

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -26,7 +26,6 @@ export {
   bumpPairCounts,
   topAffinityFor,
   shortestPath,
-  type SeasonPairs,
 } from './seasonPairs.js';
 
 export { generateInviteCommand } from './inviteCommand.js';
@@ -56,5 +55,4 @@ export { todayPST } from './dateHelpers.js';
 export {
   encodeGroupHistoryRounds,
   decodeGroupHistoryRounds,
-  type WireRound,
 } from './groupHistoryWire.js';


### PR DESCRIPTION
## Summary

Trim the exported surface area of several modules by dropping the `export` modifier on types/interfaces that have no external consumers. Each candidate was verified with a repo-wide grep before editing — no behavior changes, just visibility tightening.

## Files / types tightened

- `packages/shared/src/index.ts` — stop re-exporting `SeasonPairs` and `WireRound` (the source interfaces stay in `seasonPairs.ts` / `groupHistoryWire.ts`). Note: `activity/src/types.ts` defines its *own* `SeasonPairs` interface and the activity codebase imports it from `../types`, not from `@mythicplus/shared`, so this is safe.
- `packages/bot/src/core/roleUi.ts` — `ButtonStyle`
- `packages/bot/src/core/sentry.ts` — `ReportErrorContext`
- `packages/bot/src/commands/general.ts` — `EmbedData`
- `packages/bot/src/services/sessionService.ts` — `ActiveChannel`
- `activity/src/discordSdk.ts` — `DiscordContext`, `DiscordParticipant`
- `activity/src/hooks/useCharacterLookup.ts` — `CharacterData`
- `activity/src/components/PlayerChip.tsx` — `PlayerChipProps`
- `activity/src/hooks/useMediaQuery.ts` — lower-level `useMediaQuery` hook (only the breakpoint wrappers `useIsCarouselMode`, `useIsCompactPanel`, `useIsMobileLobby` are imported externally)
- `packages/functions/src/fetchWeeklyAffixes.ts` — `AffixDocument`
- `packages/functions/src/refreshCharacterMedia.ts` — `TargetSource`, `RefreshTarget`, `RefreshSummary`, `ClassifiedDocs` (the `classifyDocs` test in `tests/refreshCharacterMedia.test.ts` relies on structural typing of the return value, so dropping the named export is safe)

None of the proposals were skipped — every type listed turned out to be unused outside its source module.

## Test plan

- [x] `./scripts/verify-ts.sh` passed (lint + typecheck + 286 bot tests + shared)
- [x] `npm -w packages/functions run typecheck` and `npm -w packages/functions run test` passed (54 tests)
- [x] `cd activity && npm run typecheck && npm run build` passed

Footer: Generated by /overnight run 20260507-153155