### PR TITLE
fix(functions): use firebase-functions logger for season config error

### DIFF
--- a/packages/functions/src/fetchWeeklyAffixes.ts
+++ b/packages/functions/src/fetchWeeklyAffixes.ts
@@ -1,3 +1,4 @@
+import { logger } from 'firebase-functions';
 import { onSchedule } from 'firebase-functions/v2/scheduler';
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { getFirestore, FieldValue } from 'firebase-admin/firestore';
@@ -88,7 +89,7 @@ export async function fetchAndWriteAffixes(): Promise<Omit<AffixDocument, 'lastU
     const seasonInfo = await fetchCurrentSeasonInfo();
     await writeSeasonConfig(db as never, seasonInfo, () => FieldValue.serverTimestamp());
   } catch (err) {
-    console.error('[fetchAndWriteAffixes] season config write failed:', err);
+    logger.error('[fetchAndWriteAffixes] season config write failed', err);
   }
 
   return doc;


### PR DESCRIPTION
## Summary

Replace the lone `console.error` site in `packages/functions/src/fetchWeeklyAffixes.ts` with `logger.error` from `firebase-functions`.

## Style decision (LAW)

Cloud Functions log via `firebase-functions/logger`, **not** `console.*`. Using `logger.*` ensures messages flow into Cloud Logging with proper severity and structured payloads (errors are surfaced correctly in the GCP console and Sentry/alerting).

The other `logger.*` sites in `packages/functions/src/` (`githubWebhook.ts`, `refreshCharacterMedia.ts`) already follow this pattern; this brings the `season config write failed` catch-handler in `fetchAndWriteAffixes` in line with the rest of the package.

A grep over `packages/functions/src/` confirms this was the only remaining `console.*` call.

## Test plan

- [x] `./scripts/verify-ts.sh` passed (lint + typecheck + tests)

---

Generated by /overnight run 20260507-153155