### PR TITLE
chore(types): explicit return types and safer log coercion

### DIFF
--- a/packages/bot/src/core/logger.ts
+++ b/packages/bot/src/core/logger.ts
@@ -6,7 +6,7 @@ const logger = winston.createLogger({
   format: winston.format.combine(
     winston.format.timestamp(),
     winston.format.printf(({ timestamp, level, message }) => {
-      return `${timestamp as string} [${level.toUpperCase()}] ${message as string}`;
+      return `${String(timestamp)} [${level.toUpperCase()}] ${String(message)}`;
     }),
   ),
   transports: [

--- a/packages/bot/src/core/sentry.ts
+++ b/packages/bot/src/core/sentry.ts
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/node';
 import logger from './logger.js';
 import { SENTRY_DSN, GIT_SHA } from './config.js';
 
-export function initSentry() {
+export function initSentry(): void {
   if (!SENTRY_DSN) return;
 
   Sentry.init({

--- a/packages/functions/src/rateLimit.ts
+++ b/packages/functions/src/rateLimit.ts
@@ -1,7 +1,7 @@
 import { getFirestore, FieldValue } from 'firebase-admin/firestore';
 import { HttpsError } from 'firebase-functions/v2/https';
 
-export async function enforceRateLimit(uid: string, endpoint: string, maxRequests: number = 30, windowMs: number = 60000) {
+export async function enforceRateLimit(uid: string, endpoint: string, maxRequests: number = 30, windowMs: number = 60000): Promise<void> {
   const db = getFirestore();
   const ref = db.doc(`rateLimits/${uid}_${endpoint}`);
   await db.runTransaction(async (t) => {


### PR DESCRIPTION
## Summary

Three tiny type-safety fixes in a single PR:

- **`packages/bot/src/core/sentry.ts`**: Add explicit `: void` return type to `initSentry`. Aligns with the sibling exported `reportError` which already declares `: void`.
- **`packages/functions/src/rateLimit.ts`**: Add explicit `: Promise<void>` return type to `enforceRateLimit`. Matches the convention used by sibling exported async functions in this package (`writeSeasonConfig`, `fetchAndWriteAffixes`, `handleIssueWebhook`).
- **`packages/bot/src/core/logger.ts`**: Replace `as string` casts in the winston printf formatter with `String(...)` coercion so non-string log inputs render safely without unsafe casts.

## Test plan

- [x] `./scripts/verify-ts.sh` passes (lint + typecheck + tests across `shared`, `bot`, `functions`).

Generated by /overnight run 20260507-153155