### PR TITLE
fix(bot): handle null member in role:edit button handler

### DIFF
--- a/packages/bot/src/main.ts
+++ b/packages/bot/src/main.ts
@@ -1068,7 +1068,11 @@ async function main() {
 
     if (customId === 'role:edit') {
       // Start role selection for the user who clicked
-      const member = interaction.member as import('discord.js').GuildMember;
+      const member = interaction.member as import('discord.js').GuildMember | null;
+      if (!member) {
+        await interaction.reply({ content: '❌ This must be used in a server.', ephemeral: true });
+        return;
+      }
       const discordId = interaction.user.id;
       const playerName = getWowName(adaptMember(member));
       const prefix = `role:${discordId}`;


### PR DESCRIPTION
## Summary

The `role:edit` button handler in `packages/bot/src/main.ts` (around line 1071) cast `interaction.member` to `GuildMember` (non-null), which is a type lie. Discord.js types `interaction.member` as `GuildMember | APIInteractionGuildMember | null`, and the button can fire from a DM-like context where member is null. The subsequent `getWowName(adaptMember(null))` would crash at runtime.

## Fix

- Cast to `GuildMember | null` (matches existing patterns in `getReporterName` line ~110 and `handleSlashCommand` line ~684).
- If null, reply ephemerally and return early with the same `❌` style used elsewhere in the button handler.

## Test plan

- [x] `./scripts/verify-ts.sh` passes (lint + typecheck + tests)
- [ ] Manual: clicking the "Edit My Roles" button from inside a server still opens the role-selection flow as before
- [ ] Manual: the button does not crash if pressed from a DM-like context

Generated by /overnight run 20260507-153155