### PR TITLE
chore(types): add SeasonPairs to GuildData; collapse double-cast in firestoreService

### DIFF
--- a/activity/src/services/firestoreService.ts
+++ b/activity/src/services/firestoreService.ts
@@ -104,9 +104,7 @@ class FirestoreSessionService implements SessionService {
         if (docSnap.exists()) {
           const data = docSnap.data() as GuildData;
           s.setGuildData(data);
-          const sp = (data as unknown as Record<string, unknown>).seasonPairs as
-            | { seasonSlug?: unknown; counts?: unknown }
-            | undefined;
+          const sp = data.seasonPairs;
           if (
             sp &&
             typeof sp.seasonSlug === 'string' &&

--- a/activity/src/types.ts
+++ b/activity/src/types.ts
@@ -1,4 +1,12 @@
-import type { WoWPlayerDict, WoWGroupDict, SessionStatus, CharacterClass } from '@mythicplus/shared';
+import type {
+  WoWPlayerDict,
+  WoWGroupDict,
+  SessionStatus,
+  CharacterClass,
+  SeasonPairs,
+} from '@mythicplus/shared';
+
+export type { SeasonPairs };
 
 export interface WheelEntry {
   name: string;
@@ -29,6 +37,7 @@ export interface GuildData {
     // through parseExistingRounds() in firestoreService.ts to normalize.
     rounds: unknown[];
   };
+  seasonPairs?: SeasonPairs;
   refreshRequest?: unknown;
   createdAt: unknown;
   lastActive: unknown;
@@ -64,7 +73,3 @@ export interface SeasonConfig {
   expansionId: number;
 }
 
-export interface SeasonPairs {
-  seasonSlug: string;
-  counts: Record<string, number>;
-}


### PR DESCRIPTION
## Summary
- Single-source `SeasonPairs` from `@mythicplus/shared` in `activity/src/types.ts` (was a duplicated local interface; now a re-export so `import { SeasonPairs } from '../types'` callers continue to work).
- Add `seasonPairs?: SeasonPairs` field to the `GuildData` interface.
- In `activity/src/services/firestoreService.ts`, replace the double-cast `(data as unknown as Record<string, unknown>).seasonPairs as { ... }` with a typed `data.seasonPairs` read. Runtime `typeof` narrowing is preserved since Firestore wire data is still untrusted.

## Test plan
- [x] `./scripts/verify-ts.sh` passes (lint + typecheck + tests).
- [x] `cd activity && npm run typecheck` produces only pre-existing baseline errors in `views/*.tsx` (unchanged from `main`); no new errors from this change.

Generated by /overnight run 20260507-153155