### PR TITLE
test(bot): use canonical todayPST() helper in groupService tests

### DIFF
--- a/packages/bot/tests/groupService.test.ts
+++ b/packages/bot/tests/groupService.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { WoWPlayer, WoWGroup } from '@mythicplus/shared';
+import { WoWPlayer, WoWGroup, todayPST } from '@mythicplus/shared';
 
 const { mockFirebaseInstance } = vi.hoisted(() => {
   const mockFirebaseInstance = {
@@ -307,7 +307,7 @@ describe('GroupService Firebase groupHistory integration', () => {
 
     const tank = WoWPlayer.create('Tank1', ['Tank']);
     const round = [new WoWGroup(tank, null, []).toDict()];
-    const today = new Date().toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' });
+    const today = todayPST();
     mockFirebaseInstance.getGroupHistory.mockResolvedValue({ date: today, rounds: [round] });
 
     vi.mocked(getDebugPlayers).mockReturnValue([tank]);
@@ -346,7 +346,7 @@ describe('GroupService Firebase groupHistory integration', () => {
 
     const tank = WoWPlayer.create('Tank1', ['Tank']);
     const group = new WoWGroup(tank, null, []);
-    const today = new Date().toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' });
+    const today = todayPST();
 
     mockFirebaseInstance.getGroupHistory.mockResolvedValue(null);
     vi.mocked(getDebugPlayers).mockReturnValue([tank]);
@@ -371,7 +371,7 @@ describe('GroupService Firebase groupHistory integration', () => {
 
     const tank = WoWPlayer.create('Tank1', ['Tank']);
     const group = new WoWGroup(tank, null, []);
-    const today = new Date().toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' });
+    const today = todayPST();
 
     const existingRound = [new WoWGroup(tank, null, []).toDict()];
     mockFirebaseInstance.getGroupHistory.mockResolvedValue({ date: today, rounds: [existingRound] });


### PR DESCRIPTION
## Summary

Three test cases in `packages/bot/tests/groupService.test.ts` (lines 310, 349, 374) inlined `new Date().toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' })` to compute "today" for group history assertions.

Per the style decision (LAW), "today" for group history is the canonical `todayPST()` helper from `@mythicplus/shared/dateHelpers`, not a hand-duplicated copy of its current formatting. The inlines bypass the helper, so a future change to the helper's format (e.g., switching to an ISO string with day-of-week) would silently break the tests' invariants without exercising the helper at all.

This swaps the three inlines for `todayPST()` and adds it to the existing `@mythicplus/shared` import — no behavior change today, just a guard against drift.

## Test plan

- [x] `./scripts/verify-ts.sh` passes (lint + typecheck + 286 tests)
- [x] Diff is the minimum: 4 lines changed (1 import update + 3 inline replacements)

---

Generated by /overnight run 20260507-153155

🤖 Generated with [Claude Code](https://claude.com/claude-code)