### PR TITLE
feat(a11y): add aria attributes for screen-reader navigation

### DIFF
--- a/activity/src/components/AffixBar.tsx
+++ b/activity/src/components/AffixBar.tsx
@@ -23,6 +23,7 @@ export function AffixBar() {
                 target="_blank"
                 rel="noopener noreferrer"
                 className="affix-name"
+                aria-label={`${affix.name} (opens on Wowhead)`}
               >
                 {affix.name}
               </a>

--- a/activity/src/components/CharacterHeader.tsx
+++ b/activity/src/components/CharacterHeader.tsx
@@ -16,7 +16,7 @@ export function CharacterHeader({ name, subtitle, color = 'var(--color-tank)', i
         {proxiedUrl ? (
           <img
             src={proxiedUrl}
-            alt={`${name} character model`}
+            alt=""
             className="character-header__img"
           />
         ) : (

--- a/activity/src/components/ConfirmBackDialog.tsx
+++ b/activity/src/components/ConfirmBackDialog.tsx
@@ -30,7 +30,7 @@ export function ConfirmBackDialog({
 
   return (
     <div className="edit-modal-backdrop" ref={backdropRef} onClick={handleBackdropClick}>
-      <div className="spin-warning" role="alertdialog" aria-label={title}>
+      <div className="spin-warning" role="alertdialog" aria-modal="true" aria-label={title}>
         <div className="spin-warning__icon">&#x26A0;&#xFE0F;</div>
         <h3 className="spin-warning__title">{title}</h3>
         <p className="spin-warning__subtitle">{message}</p>

--- a/activity/src/components/MobilePlayerDrawer.tsx
+++ b/activity/src/components/MobilePlayerDrawer.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useState, useCallback, useRef, useEffect, useId } from 'react';
 import { PlayerCard } from './PlayerCard';
 import { getPrimaryRole, ROLE_LABELS } from '../lib/roles';
 import type { WoWPlayer } from '../types';
@@ -10,6 +10,7 @@ interface MobilePlayerDrawerProps {
 export function MobilePlayerDrawer({ player }: MobilePlayerDrawerProps) {
   const [expanded, setExpanded] = useState(false);
   const backdropRef = useRef<HTMLDivElement>(null);
+  const bodyId = useId();
 
   const toggle = useCallback(() => setExpanded((v) => !v), []);
 
@@ -43,6 +44,7 @@ export function MobilePlayerDrawer({ player }: MobilePlayerDrawerProps) {
           className="mobile-drawer__header"
           onClick={toggle}
           aria-expanded={expanded}
+          aria-controls={bodyId}
           aria-label={expanded ? 'Collapse player card' : 'Expand player card'}
         >
           <div className="mobile-drawer__info">
@@ -64,7 +66,7 @@ export function MobilePlayerDrawer({ player }: MobilePlayerDrawerProps) {
             {expanded ? '\u25BE' : '\u25B4'}
           </span>
         </button>
-        <div className="mobile-drawer__body">
+        <div className="mobile-drawer__body" id={bodyId}>
           <PlayerCard player={player} />
         </div>
       </div>

--- a/activity/src/components/ReportBadGroupDialog.tsx
+++ b/activity/src/components/ReportBadGroupDialog.tsx
@@ -38,7 +38,7 @@ export function ReportBadGroupDialog({ onClose, onSubmit }: ReportBadGroupDialog
 
   return (
     <div className="edit-modal-backdrop" ref={backdropRef} onClick={handleBackdropClick}>
-      <div className="report-dialog" role="dialog" aria-label="Report bad group">
+      <div className="report-dialog" role="dialog" aria-modal="true" aria-label="Report bad group">
         <h3 className="report-dialog__title">Report Bad Group</h3>
         <p className="report-dialog__subtitle">
           Tell us what looks wrong with this group formation — we'll review it and improve the algorithm.

--- a/activity/src/components/SpinWarningDialog.tsx
+++ b/activity/src/components/SpinWarningDialog.tsx
@@ -33,7 +33,7 @@ export function SpinWarningDialog({
 
   return (
     <div className="edit-modal-backdrop" ref={backdropRef} onClick={handleBackdropClick}>
-      <div className="spin-warning" role="alertdialog" aria-label="Not everyone is ready">
+      <div className="spin-warning" role="alertdialog" aria-modal="true" aria-label="Not everyone is ready">
         <div className="spin-warning__icon">&#x26A0;&#xFE0F;</div>
         <h3 className="spin-warning__title">Not Everyone Is Ready</h3>
         <p className="spin-warning__subtitle">Some players haven't finished setting up</p>

--- a/activity/src/components/SpotlightPortrait.tsx
+++ b/activity/src/components/SpotlightPortrait.tsx
@@ -72,6 +72,7 @@ export function SpotlightPortrait({ name, characterClass, mediaUrl, scores }: Sp
       style={{ '--ch-color': color } as React.CSSProperties}
       title={hasTooltip ? undefined : name}
       tabIndex={hasTooltip ? 0 : undefined}
+      aria-label={hasTooltip ? `${name} character portrait, score details available` : undefined}
       {...getReferenceProps()}
     >
       <div className="spotlight-portrait__stage">

--- a/activity/src/index.css
+++ b/activity/src/index.css
@@ -4088,3 +4088,19 @@ button.role-section-header--collapsible {
   width: 100%; padding: 8px 0; background: transparent; border: 0;
   color: inherit; cursor: pointer; text-align: left;
 }
+
+/* ============================================
+   Accessibility: visually hidden but available
+   to screen readers (e.g. for aria-live regions)
+   ============================================ */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/activity/src/views/WheelsView.tsx
+++ b/activity/src/views/WheelsView.tsx
@@ -366,6 +366,9 @@ export function WheelsView({ onNavigate }: WheelsViewProps) {
         avatar={<HeaderProfileSlot />}
       />
       <main className="content-area">
+        <div className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+          {wheelStatus}
+        </div>
         <section id="view-wheels">
           <div className="wheels-content">
             <div style={{ position: 'relative', flex: 1, minWidth: 0, minHeight: 0, display: 'flex', flexDirection: 'column' }}>


### PR DESCRIPTION
## Summary

Bundle of additive aria-* attributes that improve screen-reader navigation across the activity UI. All changes are invisible-only attribute additions or visually-hidden status nodes — no visible DOM or computed-style changes.

### Changes

- **SpotlightPortrait**: Add `aria-label` to the focusable wrapper when the score tooltip is enabled, so screen-reader users hear `"<name> character portrait, score details available"` instead of an unnamed focusable element.
- **WheelsView**: Add a visually-hidden `<div role="status" aria-live="polite" aria-atomic="true">{wheelStatus}</div>` near the start of `<main>` so spin progress (`Calculating...`, `Spinning for Group N...`, `Group N Formed!`) is announced to screen readers.
- **ConfirmBackDialog / SpinWarningDialog / ReportBadGroupDialog**: Add `aria-modal="true"` to the `role="dialog"` / `role="alertdialog"` element so assistive tech treats the underlying page content as inert.
- **CharacterHeader**: Mark the character-model `<img>` as decorative (`alt=""`); the visible name is already rendered as a sibling text node below the avatar.
- **MobilePlayerDrawer**: Wire `aria-controls` on the header button to a `useId()`-generated id on the body div, completing the disclosure pattern with the existing `aria-expanded`.
- **AffixBar**: Add `aria-label="<affix-name> (opens on Wowhead)"` to each wowhead link so screen readers announce that the link opens externally.
- **index.css**: Add a minimal `.sr-only` utility class (no other styles affected).

### Skipped

- `CollapsibleRoleSection` — wiring `aria-controls` would require wrapping `{children}` in a new `<div>` (since fragments can't carry an id), which changes DOM structure and could affect layout snapshots.

Visually-additive only — no Playwright snapshot regen needed.

## Test plan

- [x] `./scripts/verify-ts.sh` passes (lint + typecheck + bot tests)
- [x] `cd activity && npm run typecheck` passes
- [x] `cd activity && npm run build` passes
- [ ] Visual snapshots remain identical (no rerender expected — all attribute-only or visually-hidden additions)

Generated by /overnight run 20260507-153155

🤖 Generated with [Claude Code](https://claude.com/claude-code)