### PR TITLE
refactor(shared): extract realmToSlug + parseInGameName + DEFAULT_REGION

### DIFF
--- a/activity/src/components/RoleEditor.tsx
+++ b/activity/src/components/RoleEditor.tsx
@@ -14,7 +14,8 @@ import {
   type RoleButtonDef,
 } from '../lib/roles';
 import { reportError } from '../lib/sentry';
-import { saveStoredDiscordId, type StoredCharacter, parseInGameName } from '../lib/currentCharacter';
+import { saveStoredDiscordId, type StoredCharacter } from '../lib/currentCharacter';
+import { parseInGameName, DEFAULT_REGION } from '@mythicplus/shared';
 
 interface RoleEditorProps {
   player: WoWPlayer;
@@ -30,7 +31,6 @@ interface RoleEditorProps {
 }
 
 const LOOKUP_DEBOUNCE_MS = 800;
-const DEFAULT_REGION = 'us';
 
 export function RoleEditor({ player, onMediaUrlChange, hideSitOut, isProfileEdit }: RoleEditorProps) {
   const sittingOut = useAppStore((s) => s.channelData?.sittingOut) ?? [];

--- a/activity/src/hooks/useDungeonSuggestions.ts
+++ b/activity/src/hooks/useDungeonSuggestions.ts
@@ -6,8 +6,7 @@ import { computeDungeonRanking } from '../lib/dungeonSuggestions';
 import type { DungeonSuggestionsState } from '../lib/dungeonSuggestions';
 import type { WoWPlayer } from '../types';
 import { reportError } from '../lib/sentry';
-
-const DEFAULT_REGION = 'us';
+import { parseInGameName, DEFAULT_REGION } from '@mythicplus/shared';
 
 interface FetchState {
   phase: 'idle' | 'loading' | 'fetched' | 'no-targets';
@@ -51,26 +50,6 @@ export interface UseDungeonSuggestionsResult {
    * are absent until the fetch settles. Lookup failures map to `null`.
    */
   scoresByDiscordId: ReadonlyMap<string, CharacterDungeonScores | null>;
-}
-
-function realmToSlug(realm: string): string {
-  return realm
-    .trim()
-    .toLowerCase()
-    .replace(/'/g, '')
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '');
-}
-
-function parseInGameName(input: string | undefined | null): { name: string; realmSlug: string } | null {
-  if (!input) return null;
-  const trimmed = input.trim();
-  const dashIdx = trimmed.indexOf('-');
-  if (dashIdx === -1) return null;
-  const name = trimmed.slice(0, dashIdx).trim();
-  const realm = trimmed.slice(dashIdx + 1).trim();
-  if (!name || !realm) return null;
-  return { name, realmSlug: realmToSlug(realm) };
 }
 
 function buildPlayerTargets(players: readonly WoWPlayer[]): PlayerTarget[] {

--- a/activity/src/lib/currentCharacter.ts
+++ b/activity/src/lib/currentCharacter.ts
@@ -1,6 +1,11 @@
 import type { CharacterClass } from '@mythicplus/shared';
 import { toCharacterClass } from '@mythicplus/shared';
 
+// Re-exported for backward compatibility with existing activity callers that
+// import these from `lib/currentCharacter`. Canonical implementations live in
+// `@mythicplus/shared` (see packages/shared/src/realmSlug.ts).
+export { realmToSlug, parseInGameName, DEFAULT_REGION } from '@mythicplus/shared';
+
 export const CHARACTER_KEY = 'wheelson-character';
 export const DISCORD_ID_KEY = 'wheelson-discord-id';
 const LEGACY_PREFIX = 'wheelson-player-';
@@ -59,34 +64,6 @@ export function loadStoredDiscordId(): string | null {
 
 export function saveStoredDiscordId(discordId: string): void {
   localStorage.setItem(DISCORD_ID_KEY, discordId);
-}
-
-/**
- * Convert a realm display name to its slug form (lowercase, dash-separated,
- * no apostrophes). E.g. `"Kel'Thuzad"` → `"kelthuzad"`, `"Area 52"` → `"area-52"`.
- */
-export function realmToSlug(realm: string): string {
-  return realm
-    .trim()
-    .toLowerCase()
-    .replace(/'/g, '')
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '');
-}
-
-/**
- * Parse a "Name-Realm" combined input into the character name and realm slug.
- * Returns null when input has no dash, or either side is empty after trim.
- */
-export function parseInGameName(input: string | undefined | null): { name: string; realmSlug: string } | null {
-  if (!input) return null;
-  const trimmed = input.trim();
-  const dashIdx = trimmed.indexOf('-');
-  if (dashIdx === -1) return null;
-  const name = trimmed.slice(0, dashIdx).trim();
-  const realm = trimmed.slice(dashIdx + 1).trim();
-  if (!name || !realm) return null;
-  return { name, realmSlug: realmToSlug(realm) };
 }
 
 /**

--- a/packages/functions/src/refreshCharacterMedia.ts
+++ b/packages/functions/src/refreshCharacterMedia.ts
@@ -2,6 +2,7 @@ import { onSchedule } from 'firebase-functions/v2/scheduler';
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { logger } from 'firebase-functions';
 import { getFirestore, FieldValue, type Firestore } from 'firebase-admin/firestore';
+import { parseInGameName, DEFAULT_REGION } from '@mythicplus/shared';
 import { getBattleNetClient, type BattleNetClient } from './battlenet.js';
 import { buildCharacterResult, type CharacterResult } from './lookupCharacter.js';
 import { enforceRateLimit } from './rateLimit.js';
@@ -42,31 +43,6 @@ const CHARACTER_FIELDS_TO_CLEAR = [
   'mediaUrlUpdatedAt',
   'wowName', // legacy, no readers remain
 ] as const;
-
-const DEFAULT_REGION = 'us';
-
-// Mirrors activity/src/components/RoleEditor.tsx. Apostrophes are stripped
-// entirely (Kel'Thuzad → kelthuzad); any other non-alphanumeric run collapses
-// to a single hyphen so inputs with stray spacing (e.g. "Azjol - Nerub") still
-// produce a valid slug.
-function realmToSlug(realm: string): string {
-  return realm
-    .trim()
-    .toLowerCase()
-    .replace(/'/g, '')
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '');
-}
-
-function parseInGameName(input: string): { name: string; realm: string } | null {
-  const trimmed = input.trim();
-  const dashIdx = trimmed.indexOf('-');
-  if (dashIdx === -1) return null;
-  const name = trimmed.slice(0, dashIdx).trim();
-  const realm = trimmed.slice(dashIdx + 1).trim();
-  if (!name || !realm) return null;
-  return { name, realm: realmToSlug(realm) };
-}
 
 function readLinkedCharacter(data: Record<string, unknown>): LinkedCharacter | null {
   const linked = data.linkedCharacter as LinkedCharacter | undefined;
@@ -109,7 +85,7 @@ export function classifyDocs(
     if (parsed) {
       targets.push({
         discordId: doc.id,
-        linkedCharacter: { name: parsed.name, realm: parsed.realm, region: DEFAULT_REGION },
+        linkedCharacter: { name: parsed.name, realm: parsed.realmSlug, region: DEFAULT_REGION },
         source: 'inGameName',
       });
       continue;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -53,6 +53,8 @@ export { CHARACTER_CLASSES, toCharacterClass, toRole, toUtility } from './types.
 
 export { todayPST } from './dateHelpers.js';
 
+export { realmToSlug, parseInGameName, DEFAULT_REGION } from './realmSlug.js';
+
 export {
   encodeGroupHistoryRounds,
   decodeGroupHistoryRounds,

--- a/packages/shared/src/realmSlug.ts
+++ b/packages/shared/src/realmSlug.ts
@@ -1,0 +1,39 @@
+/**
+ * Default region used when an explicit region isn't supplied. The activity and
+ * functions packages both target US realms — this is the assumed fallback.
+ */
+export const DEFAULT_REGION = 'us';
+
+/**
+ * Convert a realm display name to its slug form (lowercase, dash-separated,
+ * no apostrophes). E.g. `"Kel'Thuzad"` → `"kelthuzad"`, `"Area 52"` → `"area-52"`.
+ *
+ * Apostrophes are stripped entirely; any other non-alphanumeric run collapses
+ * to a single hyphen so inputs with stray spacing (e.g. "Azjol - Nerub") still
+ * produce a valid slug.
+ */
+export function realmToSlug(realm: string): string {
+  return realm
+    .trim()
+    .toLowerCase()
+    .replace(/'/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+/**
+ * Parse a "Name-Realm" combined input into the character name and realm slug.
+ * Returns null when input has no dash, or either side is empty after trim.
+ */
+export function parseInGameName(
+  input: string | undefined | null,
+): { name: string; realmSlug: string } | null {
+  if (!input) return null;
+  const trimmed = input.trim();
+  const dashIdx = trimmed.indexOf('-');
+  if (dashIdx === -1) return null;
+  const name = trimmed.slice(0, dashIdx).trim();
+  const realm = trimmed.slice(dashIdx + 1).trim();
+  if (!name || !realm) return null;
+  return { name, realmSlug: realmToSlug(realm) };
+}


### PR DESCRIPTION
## Summary
Move three duplicated helpers (`realmToSlug`, `parseInGameName`, `DEFAULT_REGION`) into `@mythicplus/shared` as a single source of truth. Activity callers continue to work through a re-export from `lib/currentCharacter`, so existing imports such as `useIdentity` are unaffected.

- Canonical implementations now live in `packages/shared/src/realmSlug.ts` (re-exported from `packages/shared/src/index.ts`).
- `activity/src/lib/currentCharacter.ts` re-exports from shared (backward-compat).
- `activity/src/components/RoleEditor.tsx` and `activity/src/hooks/useDungeonSuggestions.ts` import directly from shared and drop their local duplicates.
- `packages/functions/src/refreshCharacterMedia.ts` does the same; the parse-result accessor switches from `parsed.realm` to `parsed.realmSlug` to match the canonical shape that the activity tests already exercise.

After this change `grep -rn "function realmToSlug\|const DEFAULT_REGION = 'us'\|function parseInGameName"` returns exactly three matches, all in `packages/shared/src/realmSlug.ts`.

## Test plan
- [x] `./scripts/verify-ts.sh` passes (lint + typecheck + tests across shared/bot/functions, including the existing `classifyDocs` tests in `refreshCharacterMedia.test.ts`).
- [x] `cd activity && npm run typecheck` passes.
- [x] `cd activity && npx vitest run --project unit` passes (134/134, including the existing `currentCharacter.test.ts` realm/parse assertions).
- [x] `cd activity && npm run build` succeeds.

Generated by /overnight run 20260507-153155