### PR TITLE
chore(deps): bump zod ^3.25.76 and firebase-admin ^13.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7921,9 +7921,9 @@
       }
     },
     "node_modules/firebase-admin": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.7.0.tgz",
-      "integrity": "sha512-o3qS8zCJbApe7aKzkO2Pa380t9cHISqeSd3blqYTtOuUUUua3qZTLwNWgGUOss3td6wbzrZhiHIj3c8+fC046Q==",
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.8.0.tgz",
+      "integrity": "sha512-iawoQkmZbsA+2DY5UEuB8f6jSlskzzySoye0D2F6e3zlDZX9DUcXf0HhZqLUn/P6WhLGvTf6ZtCmshZvhAgTYg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
@@ -7934,7 +7934,7 @@
         "google-auth-library": "^10.6.1",
         "jsonwebtoken": "^9.0.0",
         "jwks-rsa": "^3.1.0",
-        "node-forge": "^1.3.1",
+        "node-forge": "^1.4.0",
         "uuid": "^11.0.2"
       },
       "engines": {
@@ -9799,9 +9799,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
@@ -12284,10 +12284,10 @@
         "@sentry/node": "^10.42.0",
         "discord.js": "^14.18.0",
         "dotenv": "^16.5.0",
-        "firebase-admin": "^13.4.0",
+        "firebase-admin": "^13.8.0",
         "tsx": "^4.19.4",
         "winston": "^3.17.0",
-        "zod": "^3.24.2"
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@types/node": "^22.15.0",
@@ -12300,7 +12300,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@mythicplus/shared": "*",
-        "firebase-admin": "^13.0.0",
+        "firebase-admin": "^13.8.0",
         "firebase-functions": "^6.3.0"
       },
       "devDependencies": {

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -14,10 +14,10 @@
     "@sentry/node": "^10.42.0",
     "discord.js": "^14.18.0",
     "dotenv": "^16.5.0",
-    "firebase-admin": "^13.4.0",
+    "firebase-admin": "^13.8.0",
     "tsx": "^4.19.4",
     "winston": "^3.17.0",
-    "zod": "^3.24.2"
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/node": "^22.15.0",

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@mythicplus/shared": "*",
-    "firebase-admin": "^13.0.0",
+    "firebase-admin": "^13.8.0",
     "firebase-functions": "^6.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Two semver-compatible upstream patch bumps in one PR (themes T19 + T20).

**T19 - zod**: `^3.24.2` -> `^3.25.76` (latest stable 3.x) in `packages/bot`. Used only in `packages/bot/src/core/config.ts` for env-var schema parsing; no API surface changes affect us.

**T20 - firebase-admin**: `^13.4.0` -> `^13.8.0` in `packages/bot`, and `^13.0.0` -> `^13.8.0` in `packages/functions`. firebase-admin 13.8 bumps its `node-forge` floor from `^1.3.1` to `^1.4.0`, which transitively patches 4 node-forge advisories (lockfile resolves `node-forge` 1.3.3 -> 1.4.0).

`npm audit` (high+critical): baseline **9** -> after **8**.

No `overrides` block touched (per the standing rule on root-level overrides).

## Test plan

- [x] `npm ls zod` shows 3.25.76 across the workspace
- [x] `npm ls firebase-admin` shows 13.8.0 in both bot and functions
- [x] `./scripts/verify-ts.sh` passes (lint + typecheck + 286 tests)
- [x] `npm audit --audit-level=high` shows reduced high+critical count

Generated by /overnight run 20260507-153155