### PR TITLE
docs: align ARCHITECTURE/ACTIVITY_SETUP/FIREBASE_SETUP/DEPLOYMENT with repo state

### DIFF
--- a/ACTIVITY_SETUP.md
+++ b/ACTIVITY_SETUP.md
@@ -1,6 +1,6 @@
 # Discord Activity Setup Guide
 
-This guide details how to set up the "Wheel of Names" activity for your Discord bot. This involves hosting the web files on GitHub Pages and configuring your Discord Application to recognize them.
+This guide details how to set up the Wheelson activity for your Discord bot. This involves hosting the web files on GitHub Pages and configuring your Discord Application to recognize them.
 
 ## 1. Hosting the Activity (GitHub Pages)
 
@@ -71,9 +71,9 @@ and the service account credentials.
 
 1.  Start your bot.
 2.  Join a Voice Channel in Discord.
-3.  Run the command: `/activity`.
+3.  Run the command: `/wheelson` (the legacy `/activity` alias also works).
 4.  The bot should reply with a "Join Activity" link.
-5.  Clicking the link will open your hosted Wheel of Names directly inside Discord!
+5.  Clicking the link will open the Wheelson activity directly inside Discord!
 
 ## Troubleshooting
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -10,9 +10,9 @@ This document gives a high-level picture of how the **Discord bot**, **Firebase 
 
 1. Uses Discord roles to know who can tank, heal, or DPS.
 2. Can form balanced groups and show them in Discord (`/wheel`).
-3. Can run an **Activity**: a shared lobby + “wheel” experience backed by Firebase. Someone runs `/activity` in a voice channel; others join via a Discord Activity or a browser link. The lobby stays in sync with who’s in voice; when someone clicks “Spin,” the bot computes groups and the frontend runs a wheel animation, then everyone sees the final groups.
+3. Can run an **Activity**: a shared lobby + “wheel” experience backed by Firebase. Someone runs `/wheelson` (also aliased as `/activity`) in a voice channel; others join via a Discord Activity or a browser link. The lobby stays in sync with who’s in voice; when someone clicks “Spin,” the frontend computes groups and runs a wheel animation, then everyone sees the final groups.
 
-Firebase is the **real-time bridge** between the bot and the Activity frontend: both read and write the same “session” document, so the UI and Discord stay in sync without the frontend talking to the bot directly.
+Firebase is the **real-time bridge** between the bot and the Activity frontend: both read and write the same set of guild/channel documents, so the UI and Discord stay in sync without the frontend talking to the bot directly.
 
 ---
 
@@ -39,11 +39,10 @@ flowchart TB
     end
 
     subgraph Firebase["Firebase Firestore"]
-        Sessions[Collection: sessions]
-    end
-
-    subgraph LocalStorage["Local Storage"]
-        Preferences[player_preferences.json]
+        Guilds[guilds/&#123;guildId&#125;]
+        Channels[channels/&#123;channelId&#125;]
+        Preferences[preferences/&#123;discordId&#125;]
+        Sidecars[badGroupReports, issueTracking, config]
     end
 
     subgraph Frontend["Activity Frontend (TypeScript/Vite)"]
@@ -51,19 +50,22 @@ flowchart TB
         UI --> FirestoreClient[Firestore client SDK]
     end
 
-    User -->|/activity, /wheel, voice join/leave| Channel
+    User -->|/wheelson, /wheel, voice join/leave| Channel
     Channel -->|commands, events| Bot
-    Bot -->|read/write, real-time listener| Sessions
+    Bot -->|read/write, real-time listener| Guilds
+    Bot -->|read/write, real-time listener| Channels
     Bot -->|read/write| Preferences
-    FirestoreClient -->|read/write, onSnapshot| Sessions
-    User -->|open link with sessionId| UI
+    Bot -->|listen/write| Sidecars
+    FirestoreClient -->|read/write, onSnapshot| Guilds
+    FirestoreClient -->|read/write, onSnapshot| Channels
+    FirestoreClient -->|read/write| Preferences
+    User -->|open link with guildId/channelId| UI
 ```
 
 - **Discord**: users run commands and join voice; the bot reacts to commands and voice state.
-- **Bot**: handles commands, builds groups, and owns the “session” lifecycle; it talks to Firestore via `FirebaseService` and `SessionService`.
-- **Firestore**: single source of truth for each Activity session (players, status, groups). Bot and frontend both connect to the same project.
-- **Local Storage**: persist user role preferences (Tank/Healer/DPS) in a local JSON file.
-- **Activity frontend**: a web app (Discord Activity or standalone URL) that subscribes to one session document and drives the lobby → wheel → results flow.
+- **Bot**: handles commands, builds groups, and owns the lobby/channel lifecycle; it talks to Firestore via `FirebaseService` and `SessionService`.
+- **Firestore**: shared real-time state. Per-guild docs (`guilds/`) hold voice channel lists, group history, and refresh requests; per-channel docs (`channels/`) hold the live lobby (players, status, groups). Sidecar collections (`preferences`, `badGroupReports`, `issueTracking`, `config`) handle role memory, user-submitted reports, GitHub issue tracking, and shared config (affixes, season).
+- **Activity frontend**: a web app (Discord Activity or standalone URL) that subscribes to one guild + channel document pair and drives the lobby → wheel → results flow.
 
 ---
 
@@ -71,94 +73,137 @@ flowchart TB
 
 ### 1. Discord Bot (TypeScript)
 
-- **Entrypoint**: `packages/bot/src/main.ts` — creates the bot, loads commands, syncs slash commands, and on startup cleans up old Firestore sessions (e.g. older than 24 hours).
+- **Entrypoint**: `packages/bot/src/main.ts` — creates the bot, loads commands, syncs slash commands, and on startup cleans up old Firestore channel documents (e.g. older than 24 hours).
 - **Commands** (in `packages/bot/src/commands/`):
-  - **groups**: `/wheel` (text groups), `/activity` (interactive wheel), `/badgroup` (report bad logic), and `onVoiceStateUpdate` (lobby sync).
+  - **groups**: `/wheel` (text groups), `/wheelson` (interactive wheel; `/activity` is accepted as a legacy alias), `/badgroup` (report bad logic), and `onVoiceStateUpdate` (lobby sync).
   - **general**: `/bug` & `/featurerequest` (GitHub integration), `/version`, `/status`, `/invite`.
   - **debug**: Debugging utilities.
 - **Services** (in `packages/bot/src/services/`):
   - **GroupService**: gets players from a channel (using Discord roles), runs the group-creation algorithm (`createMythicPlusGroups`), and handles the “wheel” flows.
-  - **SessionService**: creates a Firestore session when `/activity` is run, keeps a map of voice channel → session, subscribes to that session’s document, and reacts to status changes.
+  - **SessionService**: creates the Firestore guild+channel docs when `/wheelson` is run, keeps a map of voice channel → channel doc, subscribes to those documents, and reacts to status changes.
 - **Core** (in `packages/bot/src/core/`):
-  - **FirebaseService**: initializes the Firebase Admin SDK, exposes session management.
+  - **firebaseService.ts**: initializes the Firebase Admin SDK and exposes typed CRUD for guild/channel/sidecar documents.
+  - **preferenceService.ts**: reads/writes the `preferences` Firestore collection, with a local-JSON fallback when Firebase credentials are not configured.
   - **issues.ts**: **GitHub Integration**. Bridges Discord Modals to the GitHub API to automatically create issues for bugs, feature requests, and bad group reports.
   - **roleUi.ts**: **UI Components**. Contains the Discord MessageActionRow, Buttons, and Modals for the interactive Role Board.
-  - **storage.ts**: **Persistence**. Manages local JSON storage (`player_preferences.json`) for user role preferences.
+  - **storage.ts**: Local-JSON fallback used by `preferenceService.ts` when `FIREBASE_CREDENTIALS_JSON` is unset.
 - **Shared** (in `packages/shared/src/`):
   - **parallelGroupCreator**, **models**: shared group algorithm and data models used by both the bot and frontend mock data.
 
-The bot does **not** serve the Activity UI; it only creates sessions, reacts to Firestore updates, and posts messages/embeds in Discord.
+The bot does **not** serve the Activity UI; it only creates the guild/channel docs, reacts to Firestore updates, and posts messages/embeds in Discord.
 
-### 2. Data Persistence (Hybrid Model)
+### 2. Data Persistence (Firestore-first with local fallback)
 
-The system uses a **Hybrid Persistence** model:
+The system uses Firestore as the primary store, with a local-JSON fallback for preferences when Firebase credentials are not configured:
 
 1.  **Firebase Firestore (Cloud)**:
-    *   **Purpose**: Real-time synchronization of "Activity Sessions" between the TypeScript Bot and the TypeScript Frontend.
-    *   **Scope**: Ephemeral. Sessions are created on demand and cleaned up after 24 hours.
-    *   **Collection**: `sessions`.
+    *   **Purpose**: Real-time synchronization between the bot and the Activity frontend, plus durable storage for user preferences and operational metadata.
+    *   **Scope**: Per-channel `channels/` docs are ephemeral (cleaned up after 24h on startup); per-guild `guilds/` docs and `preferences/` docs persist.
+    *   **Collections**: `guilds`, `channels`, `preferences`, `badGroupReports`, `issueTracking`, `config` (see Section 3 below).
 
-2.  **Local JSON (Disk)**:
-    *   **Purpose**: Long-term storage of user role preferences (e.g., "Player A prefers Tank").
+2.  **Local JSON (Disk, fallback only)**:
+    *   **Purpose**: Used by `core/storage.ts` and `core/preferenceService.ts` as a fallback for role preferences when `FIREBASE_CREDENTIALS_JSON` is unset.
     *   **Scope**: Persistent across restarts (volume mounted in Docker).
-    *   **File**: `player_preferences.json` (managed by `core/storage.ts`).
+    *   **File**: `player_preferences.json` (the canonical source is the Firestore `preferences` collection in normal operation).
 
 ### 3. Firebase (Firestore)
 
-- **Role**: Real-time sync between the bot and the Activity frontend. No direct HTTP API between frontend and bot.
-- **Data**: One collection, `sessions`. Each document is one Activity instance.
+- **Role**: Real-time sync between the bot and the Activity frontend, plus durable preference and metadata storage. No direct HTTP API between frontend and bot.
+- **Data**: Several top-level collections — see the layout below.
 
-**Session document shape (conceptual):**
+**Collection layout:**
 
-| Field       | Type     | Description |
-|------------|----------|-------------|
-| `guildId`  | string   | Discord guild ID |
-| `channelId`| string   | Discord voice channel ID |
-| `status`   | string   | `lobby` → `spinning` → `completed` |
-| `players`  | array    | List of player objects (name, roles) for the lobby |
-| `groups`   | array    | Computed groups (tank, healer, dps), filled by the frontend when it transitions to `spinning` |
-| `createdAt`| timestamp| Used for cleanup of old sessions |
+| Collection         | Doc ID            | Owner / Notes |
+|--------------------|-------------------|---------------|
+| `guilds`           | `{guildId}`       | Per-guild state: `voiceChannels` list, `groupHistory`, `seasonPairs`, `refreshRequest`, plus guild metadata. |
+| `channels`         | `{channelId}`     | Per-voice-channel lobby: `players`, `status`, `groups`, `sittingOut`, `guildId` back-reference. Cleaned up after 24h on startup. |
+| `preferences`      | `{discordId}`     | Per-user saved roles, in-game name, character class, and media URL. Written by both the bot (`PreferenceService`) and the frontend. |
+| `badGroupReports`  | auto-id           | Frontend writes a doc when a user clicks "report bad group"; the bot listens and files a GitHub issue. |
+| `issueTracking`    | `{issueNumber}`   | Bot writes a tracking doc per `/bug` or `/featurerequest` so the GitHub close webhook can DM the reporter. |
+| `config`           | `affixes`, `season` | Read-only at runtime; populated by Cloud Functions. |
+
+**`channels/{channelId}` document shape:**
+
+| Field       | Type      | Description |
+|------------|-----------|-------------|
+| `channelId`| string    | Discord voice channel ID (also the doc ID) |
+| `guildId`  | string    | Back-reference to the parent guild doc |
+| `channelName` | string | Voice channel display name |
+| `status`   | string    | `lobby` → `spinning` → `completed` |
+| `players`  | array     | List of player objects (name, roles, etc.) for the lobby |
+| `groups`   | array     | Computed groups (tank, healer, dps); filled by the frontend on transition to `spinning` |
+| `sittingOut` | array   | IDs of players sitting out the current round |
+| `isDebug`  | boolean   | Whether this lobby is from `/test` |
+| `createdAt`| timestamp | Used for startup cleanup |
+| `lastActive`| timestamp | Updated on writes; used for the 24h cleanup query |
 
 ```mermaid
 erDiagram
-    sessions {
-        string documentId "session ID"
+    guilds ||--o{ channels : "owns"
+    guilds {
         string guildId
+        array voiceChannels
+        object groupHistory
+        object seasonPairs
+        object refreshRequest
+        timestamp lastActive
+    }
+    channels {
         string channelId
+        string guildId
         string status
         array players
         array groups
+        array sittingOut
         timestamp createdAt
+        timestamp lastActive
+    }
+    preferences {
+        string discordId
+        array roles
+        string wowName
+        string inGameName
+        string characterClass
+        string mediaUrl
+    }
+    badGroupReports {
+        string guildId
+        object payload
+    }
+    issueTracking {
+        number issueNumber
+        string discordUserId
+        string issueUrl
     }
 ```
 
-- **Bot**: creates the document (status `lobby`), keeps `players` in sync with the voice channel, and listens for `completed` to post the embed in Discord.
-- **Frontend**: subscribes with `onSnapshot` to the document (using `sessionId` from the URL). When the user clicks Spin it runs `createMythicPlusGroups` client-side, writes the computed `groups` plus `status: spinning` directly, then writes `status: completed` after the animation finishes. The bot does **not** compute groups in Activity mode.
+- **Bot**: creates the channel doc (status `lobby`), keeps `players` in sync with the voice channel via `SessionService`, and listens for `completed` to post the embed in Discord. It also listens to `badGroupReports` and the per-guild `refreshRequest` field.
+- **Frontend**: subscribes with `onSnapshot` to a `guilds/{guildId}` doc and a `channels/{channelId}` doc (using `guildId` and `channelId` from the URL). When the user clicks Spin it runs `createMythicPlusGroups` client-side, writes the computed `groups` plus `status: spinning` directly, then writes `status: completed` after the animation finishes. The bot does **not** compute groups in Activity mode.
 
-Security and cleanup are described in `FIREBASE_SETUP.md` (rules, session replacement, startup cleanup).
+Security rules and cleanup are described in `FIREBASE_SETUP.md` and the canonical `firestore.rules` at the repo root.
 
 ### 4. Activity Frontend (TypeScript / Vite)
 
 - **Role**: Provides the lobby and “wheel” experience for an Activity session. It is a **client-only** app that reads and writes Firestore; it never calls the bot.
-- **Entry**: `activity/src/main.tsx`. On load it reads `guildId`/`channelId` from the query string. If missing, it shows a message like “Use /activity in Discord.”
+- **Entry**: `activity/src/main.tsx`. On load it reads `guildId` and `channelId` from the query string (the Discord SDK can also supply them when launched as an Activity). `?sessionId=` is accepted as a deprecated alias for `guildId`. If neither is present, the app shows a message prompting the user to run `/wheelson` in Discord.
 - **Firebase**: Uses the Firebase JS SDK (see `activity/src/firebase.ts`) with config from `VITE_FIREBASE_*` env vars. It uses Firestore only (no Auth in the minimal setup).
 - **Flow**:
-  1. Subscribe to `sessions/{sessionId}` with `onSnapshot`.
+  1. Subscribe to `guilds/{guildId}` and `channels/{channelId}` with `onSnapshot`.
   2. **Lobby**: Always render the current `players` list; show/hide lobby vs wheel vs results based on `status`.
-  3. **Spin**: User clicks “Spin” → frontend runs `createMythicPlusGroups` client-side and writes both `groups` and `status: 'spinning'` to Firestore in one update.
+  3. **Spin**: User clicks “Spin” → frontend runs `createMythicPlusGroups` client-side and writes both `groups` and `status: 'spinning'` to the channel doc in one update.
   4. **Spinning**: Frontend animates the reveal in `activity/src/views/WheelsView.tsx`, then writes `status: 'completed'`.
-  5. **Completed**: Show final groups; if the document is deleted (e.g. new `/activity` in same channel), show “Activity ended.”
+  5. **Completed**: Show final groups; if the channel doc is deleted (e.g. new `/wheelson` in same channel), show “Activity ended.”
 
-So the frontend is a **state machine** driven by the single session document in Firestore.
+So the frontend is a **state machine** driven by the guild + channel documents in Firestore.
 
 #### Frontend Modes
 The Activity frontend (`activity/src/main.tsx`) operates in three distinct modes to support production, demos, and testing:
 
 1.  **Firebase Mode (Production):**
-    -   Triggered when a `?sessionId=...` or `?guildId=...` query parameter is present.
+    -   Triggered when a `?guildId=...` (and optionally `?channelId=...`) query parameter is present, or when launched as a Discord Activity. `?sessionId=` is also accepted as a deprecated alias for `guildId`.
     -   Connects to live Firestore to sync with the Discord bot.
 2.  **Demo Mode (Standalone):**
-    -   Triggered by clicking "Start Demo" in the UI (when no session ID is found).
+    -   Triggered by clicking "Start Demo" in the UI (when no guild/channel ID is found).
     -   Uses `mockSession` data purely in-memory. Allows users to "test drive" the UI without a Discord bot.
 3.  **Mock/Static Mode (Testing):**
     -   Triggered by injecting a base64-encoded JSON object via the `?data=...` query parameter.
@@ -203,7 +248,7 @@ sequenceDiagram
 
 ## How an Activity Run Works (End-to-End)
 
-This is the sequence from “someone runs `/activity`” to “everyone sees groups.”
+This is the sequence from “someone runs `/wheelson`” to “everyone sees groups.”
 
 ```mermaid
 sequenceDiagram
@@ -213,19 +258,19 @@ sequenceDiagram
     participant Firestore
     participant Frontend
 
-    User->>Discord: /activity (in voice channel)
+    User->>Discord: /wheelson (in voice channel)
     Discord->>Bot: command
     Bot->>Bot: GroupService.getGroupsData (players from channel)
-    Bot->>Firestore: create session (lobby, players)
-    Firestore-->>Bot: sessionId
-    Bot->>Discord: reply with Activity link + browser link (sessionId)
+    Bot->>Firestore: getOrCreate guilds/{guildId} and channels/{channelId}
+    Firestore-->>Bot: ack
+    Bot->>Discord: reply with Activity link + browser link (?guildId=..&channelId=..)
     User->>Frontend: open link (Discord Activity or browser)
-    Frontend->>Firestore: onSnapshot(session)
+    Frontend->>Firestore: onSnapshot(guilds/{guildId}, channels/{channelId})
 
     loop Lobby
         User->>Discord: join/leave voice
         Discord->>Bot: onVoiceStateUpdate
-        Bot->>Firestore: updateChannelPlayers(players)
+        Bot->>Firestore: updateChannelDoc(players)
         Firestore-->>Frontend: snapshot → update lobby
     end
 
@@ -239,9 +284,9 @@ sequenceDiagram
     Firestore-->>Frontend: snapshot → show results screen
 ```
 
-- **Creation**: Bot creates the session and returns links; frontend only needs the URL with `sessionId`.
-- **Lobby**: Bot keeps `players` in sync with voice; frontend only reads and renders.
-- **Spin**: Frontend computes `groups` client-side and writes `spinning` + `groups`; frontend animates and writes `completed`; bot listens for `completed` and posts the result embed in Discord.
+- **Creation**: Bot creates the guild + channel docs and returns links; frontend only needs the URL with `guildId`/`channelId`.
+- **Lobby**: Bot keeps `players` on the channel doc in sync with voice; frontend only reads and renders.
+- **Spin**: Frontend computes `groups` client-side and writes `spinning` + `groups` to the channel doc; frontend animates and writes `completed`; bot listens for `completed` and posts the result embed in Discord.
 
 ---
 
@@ -249,23 +294,23 @@ sequenceDiagram
 
 | Concern | Where it lives |
 |--------|-----------------|
-| Slash commands (`/activity`, `/wheel`) | `packages/bot/src/commands/groups.ts` |
-| Role Board / Saved Roles | `packages/bot/src/core/roleUi.ts`, `packages/bot/src/core/storage.ts` |
+| Slash commands (`/wheelson`, `/wheel`) | `packages/bot/src/commands/groups.ts` |
+| Role Board / Saved Roles | `packages/bot/src/core/roleUi.ts`, `packages/bot/src/core/preferenceService.ts` (Firestore + local fallback in `core/storage.ts`) |
 | GitHub Issues (`/bug`, `/badgroup`) | `packages/bot/src/core/issues.ts`, `packages/bot/src/commands/general.ts`, `packages/bot/src/commands/groups.ts` |
 | Voice → lobby sync | `packages/bot/src/commands/groups.ts` (`onVoiceStateUpdate`) → `SessionService.updateChannelPlayers` |
-| Session create/listen/update | `SessionService` + `FirebaseService` |
+| Channel/guild doc create/listen/update | `SessionService` + `FirebaseService` |
 | Group algorithm | `packages/shared/src/parallelGroupCreator.ts` |
 | “Spin” handling | Frontend: `activity/src/services/firestoreService.ts` (`requestSpin`) — runs the algorithm client-side and writes `spinning`+`groups` |
 | Activity UI and wheel | `activity/src/main.tsx`, `activity/src/views/WheelsView.tsx` |
-| Session cleanup | `packages/bot/src/main.ts` (startup), `SessionService.cleanupChannel` |
+| Channel doc cleanup | `packages/bot/src/main.ts` (startup), `SessionService.cleanupChannel` |
 
 ---
 
 ## Configuration That Ties Everything Together
 
-- **Bot ↔ Firebase**: `FIREBASE_CREDENTIALS_JSON` (service account JSON). If unset, the bot runs but Activity/session features are disabled.
+- **Bot ↔ Firebase**: `FIREBASE_CREDENTIALS_JSON` (service account JSON). If unset, the bot runs but Activity/lobby and Firestore-backed preference features are disabled (preferences fall back to local JSON).
 - **Frontend ↔ Firebase**: `VITE_FIREBASE_*` (apiKey, authDomain, projectId, etc.) in the Activity build.
-- **Activity link**: Bot builds the browser link as `ACTIVITY_URL?sessionId={sessionId}` (e.g. `ACTIVITY_URL` from env or default GitHub Pages URL).
+- **Activity link**: Bot builds the browser link as `${ACTIVITY_URL}?guildId={guildId}&channelId={channelId}` (e.g. `ACTIVITY_URL` from env or default GitHub Pages URL). The frontend also accepts `?sessionId=` as a deprecated alias for `guildId`.
 - **Discord Activity**: `DISCORD_APPLICATION_ID` is used when creating the embedded application invite for the voice channel.
 - **GitHub Integration**: `GITHUB_TOKEN`, `GITHUB_REPO_OWNER`, `GITHUB_REPO_NAME` are required for `/bug` and `/featurerequest` to work.
 
@@ -278,7 +323,7 @@ For step-by-step Firebase and env setup, see `FIREBASE_SETUP.md` and `README.md`
 ```mermaid
 flowchart LR
     subgraph Inputs
-        Cmd["/activity"]
+        Cmd["/wheelson"]
         Voice["Voice join/leave"]
         Click["Click Spin"]
         Role["Role Selection"]
@@ -288,12 +333,15 @@ flowchart LR
         GS[GroupService]
         SS[SessionService]
         FS[FirebaseService]
-        Store[Storage (JSON)]
+        PS[PreferenceService]
         Issues[GitHub Issues]
     end
 
     subgraph Firestore
-        S[(sessions)]
+        G[(guilds)]
+        C[(channels)]
+        P[(preferences)]
+        Side[(badGroupReports / issueTracking / config)]
     end
 
     subgraph Activity
@@ -304,19 +352,24 @@ flowchart LR
     Cmd --> SS
     Voice --> SS
     SS --> FS
-    FS <--> S
-    S <--> UI
+    FS <--> G
+    FS <--> C
+    PS <--> P
+    FS <--> Side
+    G <--> UI
+    C <--> UI
+    P <--> UI
     Click --> UI
-    UI --> S
-    SS --> S
-    Role --> Store
+    UI --> C
+    SS --> C
+    Role --> PS
     Cmd --> Issues
 ```
 
-- **Bot**: commands and voice events → GroupService + SessionService → FirebaseService → Firestore.
-- **Firestore**: shared session state.
-- **Activity**: URL with `sessionId` → subscribe to session → user clicks Spin → write status → read updates and drive UI.
-- **Storage**: User role preferences are saved locally.
+- **Bot**: commands and voice events → GroupService + SessionService → FirebaseService → Firestore (`guilds/`, `channels/`, sidecars).
+- **Firestore**: shared real-time state plus durable `preferences/` and operational sidecars.
+- **Activity**: URL with `guildId`/`channelId` → subscribe to guild + channel docs → user clicks Spin → write status → read updates and drive UI.
+- **Preferences**: User role preferences are persisted in the Firestore `preferences/` collection by `PreferenceService`, with local JSON as a fallback.
 - **Issues**: Bug reports are sent to GitHub.
 
 This should be enough to get a clear mental model of how the bot, Firebase, and Activity frontend work together. For implementation details, use this doc as a map and then open the referenced files.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -104,7 +104,7 @@ Click New repository secret for each:
   If fine-grained tokens do not show Packages, use a classic PAT with `read:packages`
   (and `repo` if the repo is private).
 - `BOT_TOKEN`: Discord bot token.
-- `DISCORD_APPLICATION_ID`: Discord app ID (same as the Application ID in the portal; needed for the `!activity` invite).
+- `DISCORD_APPLICATION_ID`: Discord app ID (same as the Application ID in the portal; needed for the `/wheelson` invite).
 - `GH_ISSUE_TOKEN`: GitHub PAT with `repo` scope for creating issues.
 
 ### Optional
@@ -142,7 +142,7 @@ When inviting the bot or generating an invite URL, include at least these **scop
 | **Attach Files**   | Post the wheel GIF and other assets. |
 | **Connect**        | Join voice channels. |
 | **Speak**          | Play spin/reveal sounds in voice. |
-| **Create Instant Invite** | Required for `!activity` (embedded activity invite). |
+| **Create Instant Invite** | Required for `/wheelson` (embedded activity invite). |
 | **Read Message History** | Recommended so the bot can work in existing channels. |
 
 Use **Bot** scope and the permissions above; add **applications.commands** if you use slash commands.
@@ -158,15 +158,15 @@ If you copy the **permissions integer** from the Discord Developer Portal (OAuth
 
 The permissions integer is only used when generating the OAuth2 invite URL; it does not change the bot’s behavior inside a server. Server admins still grant permissions when they complete the invite flow.
 
-### 3.4 Activity (optional, for `!activity`)
+### 3.4 Activity (optional, for `/wheelson`)
 
-The `!activity` command creates an embedded-application invite. Your app must be configured as an **Activity** in the portal:
+The `/wheelson` command (legacy alias `/activity`) creates an embedded-application invite. Your app must be configured as an **Activity** in the portal:
 
 1. In the Developer Portal: your application → **Activities** (or **Rich Presence** / app type).
 2. Create or link an Activity so Discord allows `target_type=embedded_application` invites.
 3. Set the **DISCORD_APPLICATION_ID** secret (and `DISCORD_APPLICATION_ID` in `.env` locally) to your application’s **Application ID** (Application → General Information).
 
-If Activities are not set up, `/activity` will fail; `/wheel` (voice + GIFs) still work with the permissions above.
+If Activities are not set up, `/wheelson` will fail; `/wheel` (voice + GIFs) still works with the permissions above.
 
 ## 4. First deploy
 
@@ -179,7 +179,9 @@ If Activities are not set up, `/activity` will fail; `/wheel` (voice + GIFs) sti
 
 ### 4.1 Data Persistence
 
-The bot now stores player preferences (roles) in a `data/` directory inside the repository folder on the Pi (`/home/deploy/mythic-plus-bot/data`).
+In normal production deployments (`FIREBASE_CREDENTIALS_JSON` set), player preferences are stored in the Firestore `preferences/` collection by `PreferenceService` and there is nothing to back up on the Pi.
+
+If Firebase credentials are not configured, the bot falls back to a local JSON file in the `data/` directory inside the repository folder on the Pi (`/home/deploy/mythic-plus-bot/data`):
 - This directory is created automatically by Docker when the container starts.
 - It is ignored by git (via `.gitignore`), so your data survives deployments and `git reset`.
 - You can back up this file manually: `cp /home/deploy/mythic-plus-bot/data/player_preferences.json ~/.backup_prefs.json`.
@@ -260,13 +262,3 @@ Create a new repository secret:
 - Value: (The token you copied in the previous step)
 
 This token will be injected into the container at runtime.
-
-### 7.3 Jules Automation
-
-To enable automatic fix attempts by Jules:
-
-1.  **Jules GitHub App:** Ensure the Jules app is installed on your repository (via `jules.google`).
-2.  **API Key:** Generate a Jules API Key from your [Jules Settings](https://jules.google/settings).
-3.  **GitHub Secret:** Go to your repository **Settings > Secrets and variables > Actions** and create a new Repository Secret named `JULES_API_KEY` with your key.
-
-The bot automatically adds the `jules` label to new issues, which triggers the `.github/workflows/jules-issue-fix.yml` workflow to send the issue to Jules for an automated fix attempt.

--- a/FIREBASE_SETUP.md
+++ b/FIREBASE_SETUP.md
@@ -35,36 +35,30 @@ The bot needs a Service Account to write to Firestore with admin privileges.
    ```
 
 ## 4. Production Deploy (GitHub Actions)
-For the main bot deploy (e.g. to a Raspberry Pi via `.github/workflows/deploy.yml`), set the repository secret `FIREBASE_CREDENTIALS_JSON` in GitHub (Settings → Secrets and variables → Actions). The deploy workflow passes it into the Pi environment so the container can use Firebase. Without this secret, the bot will run but Firebase features (e.g. `/activity` live lobby) will be disabled.
+For the main bot deploy (e.g. to a Raspberry Pi via `.github/workflows/deploy.yml`), set the repository secret `FIREBASE_CREDENTIALS_JSON` in GitHub (Settings → Secrets and variables → Actions). The deploy workflow passes it into the Pi environment so the container can use Firebase. Without this secret, the bot will run but Firebase features (e.g. the `/wheelson` live lobby and Firestore-backed preferences) will be disabled.
 
 ## 5. Firestore Database and Rules
 1. Go to **Firestore Database** in the left sidebar.
 2. Click "Create Database".
 3. Choose **Standard** edition and select a location (e.g. your nearest region).
 4. After the database is created, open the **Rules** tab.
-5. Replace the default rules with the following so the frontend and bot can read/write data (we rely on opaque IDs; you can add Auth or stricter rules later):
-   ```
-   rules_version = '2';
-   service cloud.firestore {
-     match /databases/{database}/documents {
-       match /guilds/{guildId} {
-         allow read, write: if true;
-       }
-       match /channels/{channelId} {
-         allow read, write: if true;
-       }
-       match /preferences/{docId} {
-         allow read, write: if true;
-       }
-     }
-   }
-   ```
-   *Warning: This allows anyone to read/write guild, channel, and preference documents. For a production app, you should restrict writes to only the fields the frontend needs to update (like status and role preferences).*
+5. The canonical security rules for this project live in [`firestore.rules`](firestore.rules) at the repo root. Copy that file into the Rules tab in the Firebase Console (or deploy via `firebase deploy --only firestore:rules`). It covers all collections used at runtime:
+
+   - `guilds/{guildId}` — public read, create, update; no delete. `guildId` field is immutable.
+   - `channels/{channelId}` — public read, create (only with status `lobby` and a real parent guild), update (status restricted to `lobby` / `spinning` / `completed`); no delete. The bot's Admin SDK bypasses these rules and handles deletes/cleanup.
+   - `preferences/{docId}` — public read, create, update; no delete.
+   - `config/{docId}` — public read; writes are server-only (Cloud Functions populate `config/affixes` and `config/season`).
+   - `rateLimits/{docId}` — server-only (read and write deny).
+   - `characters/{region}/{realm}/{name}` — server-only; reads/writes go through the `lookupCharacter` Cloud Function.
+   - `badGroupReports/{docId}` — clients can `create` only (and the doc must reference a real guild via `guildId`); read/update/delete are server-only. The bot listens server-side and files GitHub issues.
+   - `issueTracking/{issueNumber}` — implicitly server-only (no rule grants client access); written by the bot and consumed by the GitHub close webhook Cloud Function.
+
+   If you need to deviate from the canonical rules, treat `firestore.rules` as the source of truth and keep your Console copy in sync.
 
 ## 6. Document cleanup (database growth)
 
 Guild and channel documents are cleaned up so the database does not grow indefinitely:
 
 - **Completion does not trigger cleanup.** When the frontend sets `status: 'completed'`, the bot only announces results to Discord. The documents stay active so the web page remains valid (e.g. you can keep viewing results).
-- **New lobby replaces the previous one.** When someone runs `/activity` again in the same voice channel, the bot cleans up the **old** channel document first (removes from memory, unsubscribes its listener, deletes the document), then creates a new one.
-- **Startup cleanup.** On **bot startup**, the bot deletes any channel document whose `createdAt` is older than **24 hours**. You can change this by editing `FIREBASE_DOC_MAX_AGE_SECONDS` in `packages/bot/src/events/ready.ts`.
+- **New lobby replaces the previous one.** When someone runs `/wheelson` again in the same voice channel, the bot resets the existing channel document back to `status: 'lobby'` (clearing `groups`) so the Activity link continues to work.
+- **Startup cleanup.** On **bot startup**, the bot deletes any channel document whose `lastActive` is older than **24 hours**.


### PR DESCRIPTION
## Summary

Updates four top-level docs (`ARCHITECTURE.md`, `ACTIVITY_SETUP.md`, `FIREBASE_SETUP.md`, `DEPLOYMENT.md`) so they reflect what the codebase actually does today. No code changes; `./scripts/verify-ts.sh` still passes.

### `ARCHITECTURE.md`
- Replace stale `/activity` references with `/wheelson` (legacy alias noted), including the high-level flowchart, the bot commands table, the end-to-end mermaid sequence, and the summary diagram.
- Rewrite the Firestore section: describe the actual collections (`guilds`, `channels`, `preferences`, `badGroupReports`, `issueTracking`, `config`) instead of a fictional single `sessions` collection. Update the `erDiagram` and the channel-doc shape table.
- Document preferences as Firestore-first (`PreferenceService`) with the local JSON file as a graceful fallback when `FIREBASE_CREDENTIALS_JSON` is unset.
- Update query params to `guildId` / `channelId`; call out `?sessionId=` as a deprecated alias for `guildId`.

### `ACTIVITY_SETUP.md`
- Replace "Wheel of Names" branding with "Wheelson activity".
- Update slash command to `/wheelson` (legacy `/activity` alias still mentioned).

### `FIREBASE_SETUP.md`
- Replace the permissive example rules with a pointer to the canonical `firestore.rules` at the repo root, plus a summary of every collection it covers (`guilds`, `channels`, `preferences`, `config`, `rateLimits`, `characters`, `badGroupReports`, `issueTracking`).
- Update document-cleanup wording from `/activity` to `/wheelson` and reflect that re-running in the same channel resets the existing doc back to `lobby` rather than deleting it.

### `DEPLOYMENT.md`
- Drop section 7.3 ("Jules Automation"): `.github/workflows/jules-issue-fix.yml` is not present in the repo.
- Update `!activity` / `/activity` references to `/wheelson`.
- Note that production preferences live in Firestore; the local JSON `data/` path is the fallback.

## Test plan
- [x] `./scripts/verify-ts.sh` passes (lint + typecheck + unit tests).
- [ ] Sanity-read the rendered Markdown on GitHub.
- [ ] Confirm mermaid diagrams render after the rewrite.

Generated by /overnight run 20260507-153155