### PR TITLE
refactor(shared): extract parseSeasonPairs validator

### DIFF
--- a/activity/src/services/firestoreService.ts
+++ b/activity/src/services/firestoreService.ts
@@ -9,6 +9,7 @@ import {
   createMythicPlusGroups,
   decodeGroupHistoryRounds,
   encodeGroupHistoryRounds,
+  parseSeasonPairs,
   setGroupHistory,
   todayPST,
 } from '@mythicplus/shared';
@@ -104,22 +105,8 @@ class FirestoreSessionService implements SessionService {
         if (docSnap.exists()) {
           const data = docSnap.data() as GuildData;
           s.setGuildData(data);
-          const sp = (data as unknown as Record<string, unknown>).seasonPairs as
-            | { seasonSlug?: unknown; counts?: unknown }
-            | undefined;
-          if (
-            sp &&
-            typeof sp.seasonSlug === 'string' &&
-            typeof sp.counts === 'object' &&
-            sp.counts !== null
-          ) {
-            s.setSeasonPairs({
-              seasonSlug: sp.seasonSlug,
-              counts: sp.counts as Record<string, number>,
-            });
-          } else {
-            s.setSeasonPairs(null);
-          }
+          const rawSeasonPairs = (data as unknown as Record<string, unknown>).seasonPairs;
+          s.setSeasonPairs(parseSeasonPairs(rawSeasonPairs));
           s.setStatusMessage('');
           return;
         }

--- a/packages/bot/src/core/firebaseService.ts
+++ b/packages/bot/src/core/firebaseService.ts
@@ -2,6 +2,7 @@ import { createRequire } from 'node:module';
 import {
   decodeGroupHistoryRounds,
   encodeGroupHistoryRounds,
+  parseSeasonPairs,
   type WoWGroupDict,
 } from '@mythicplus/shared';
 import logger from './logger.js';
@@ -400,19 +401,7 @@ export class FirebaseService implements IFirebaseService {
     const doc = await docRef.get();
     if (!doc.exists) return null;
     const data = doc.data() ?? {};
-    const sp = data.seasonPairs as { seasonSlug?: unknown; counts?: unknown } | undefined;
-    if (
-      !sp ||
-      typeof sp.seasonSlug !== 'string' ||
-      typeof sp.counts !== 'object' ||
-      sp.counts === null
-    ) {
-      return null;
-    }
-    return {
-      seasonSlug: sp.seasonSlug,
-      counts: sp.counts as Record<string, number>,
-    };
+    return parseSeasonPairs(data.seasonPairs);
   }
 
   async saveSeasonPairs(

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -26,6 +26,7 @@ export {
   bumpPairCounts,
   topAffinityFor,
   shortestPath,
+  parseSeasonPairs,
   type SeasonPairs,
 } from './seasonPairs.js';
 

--- a/packages/shared/src/seasonPairs.ts
+++ b/packages/shared/src/seasonPairs.ts
@@ -12,6 +12,28 @@ export interface SeasonPairs {
 }
 
 /**
+ * Validate a raw Firestore value as a `SeasonPairs` shape. Returns the typed
+ * value when `raw` is an object with `seasonSlug: string` and a non-null
+ * `counts` object, or `null` otherwise. Values inside `counts` are assumed to
+ * be numbers without per-key validation (matches existing call-site behavior).
+ */
+export function parseSeasonPairs(raw: unknown): SeasonPairs | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const sp = raw as { seasonSlug?: unknown; counts?: unknown };
+  if (
+    typeof sp.seasonSlug !== 'string' ||
+    typeof sp.counts !== 'object' ||
+    sp.counts === null
+  ) {
+    return null;
+  }
+  return {
+    seasonSlug: sp.seasonSlug,
+    counts: sp.counts as Record<string, number>,
+  };
+}
+
+/**
  * Increment season pair counts by every pair in `round`. Returns a NEW map;
  * does not mutate `current`. Groups with fewer than 2 players are skipped
  * (degenerate remainders).


### PR DESCRIPTION
## Summary
- Adds `parseSeasonPairs(raw: unknown): SeasonPairs | null` to `@mythicplus/shared` (next to `bumpPairCounts`/`topAffinityFor`).
- Replaces the duplicated inline shape check in `packages/bot/src/core/firebaseService.ts` (`getSeasonPairs`) and `activity/src/services/firestoreService.ts` (`subscribeToGuild`).
- Runtime semantics are identical: requires `seasonSlug: string` and a non-null `counts: object`; preserves the existing `as Record<string, number>` cast (no per-value validation, matching pre-refactor behavior).

## Test plan
- [x] `./scripts/verify-ts.sh` (lint + typecheck + tests, 286 passed)
- [x] `cd activity && npm run typecheck && npm run build` (typecheck clean, build succeeds)

Generated by /overnight run 20260507-153155