### PR TITLE
test(shared): cover toRole/toUtility/todayPST/model toString helpers

### DIFF
--- a/packages/bot/tests/models.test.ts
+++ b/packages/bot/tests/models.test.ts
@@ -347,6 +347,75 @@ describe('WoWPlayer', () => {
       expect(restored.offmelee).toBe(original.offmelee);
     });
   });
+
+  describe('toTestString', () => {
+    it('renders a tank with brez utility', () => {
+      const player = WoWPlayer.create('TankBrez', [ROLE_TANK, ROLE_BREZ]);
+      expect(player.toTestString()).toBe('WoWPlayer.create("TankBrez", ["Tank", "Brez"])');
+    });
+
+    it('renders a ranged DPS with lust', () => {
+      const player = WoWPlayer.create('Mage', [ROLE_RANGED, ROLE_LUST]);
+      expect(player.toTestString()).toBe('WoWPlayer.create("Mage", ["Ranged", "Lust"])');
+    });
+
+    it('renders a melee main with offtank and offhealer in canonical order', () => {
+      const player = WoWPlayer.create('Flex', [
+        ROLE_MELEE,
+        ROLE_TANK_OFFSPEC,
+        ROLE_HEALER_OFFSPEC,
+      ]);
+      expect(player.toTestString()).toBe(
+        'WoWPlayer.create("Flex", ["Melee", "Tank Offspec", "Healer Offspec"])',
+      );
+    });
+
+    it('renders the full role set in canonical order regardless of input order', () => {
+      const player = WoWPlayer.create('MaxRoles', [
+        // Provide roles in scrambled order to confirm output ordering is stable.
+        ROLE_LUST,
+        ROLE_MELEE_OFFSPEC,
+        ROLE_BREZ,
+        ROLE_RANGED_OFFSPEC,
+        ROLE_HEALER_OFFSPEC,
+        ROLE_TANK,
+        ROLE_TANK_OFFSPEC,
+      ]);
+      // tankMain is set; ranged/melee main flags are not (mutually exclusive).
+      // Field order: tank, healer, ranged, melee, then offtank, offhealer,
+      // offranged, offmelee, then brez, lust.
+      expect(player.toTestString()).toBe(
+        'WoWPlayer.create("MaxRoles", ["Tank", "Tank Offspec", "Healer Offspec", "Ranged Offspec", "Melee Offspec", "Brez", "Lust"])',
+      );
+    });
+
+    it('renders an empty role list for a player with no roles', () => {
+      const player = WoWPlayer.create('NoRole', []);
+      expect(player.toTestString()).toBe('WoWPlayer.create("NoRole", [])');
+    });
+  });
+
+  describe('toUtilitiesString', () => {
+    it('renders Name(brez, lust) when the player has both utilities', () => {
+      const player = WoWPlayer.create('Hunter', [ROLE_RANGED, ROLE_BREZ, ROLE_LUST]);
+      expect(player.toUtilitiesString()).toBe('Hunter(Brez, Lust)');
+    });
+
+    it('renders Name(brez) when the player has only brez', () => {
+      const player = WoWPlayer.create('Druid', [ROLE_HEALER, ROLE_BREZ]);
+      expect(player.toUtilitiesString()).toBe('Druid(Brez)');
+    });
+
+    it('renders Name(lust) when the player has only lust', () => {
+      const player = WoWPlayer.create('Shaman', [ROLE_RANGED, ROLE_LUST]);
+      expect(player.toUtilitiesString()).toBe('Shaman(Lust)');
+    });
+
+    it('renders the bare name when the player has no utilities', () => {
+      const player = WoWPlayer.create('Rogue', [ROLE_MELEE]);
+      expect(player.toUtilitiesString()).toBe('Rogue');
+    });
+  });
 });
 
 describe('WoWGroup', () => {
@@ -419,5 +488,50 @@ describe('WoWGroup', () => {
     expect(restored.tank).toBeNull();
     expect(restored.healer).toBeNull();
     expect(restored.dps).toEqual([]);
+  });
+
+  describe('toTestString', () => {
+    it('renders a complete group with all roles and mixed utilities', () => {
+      const group = new WoWGroup(tank, healer, [dps1, dps2, dps3]);
+      // tank/healer have no utilities, dps3 has brez. Names are bare except dps3.
+      expect(group.toTestString()).toBe(
+        'WoWGroup(Tank="Tank", Healer="Healer", DPS="DPS1", "DPS2", "DPS3(Brez)")',
+      );
+    });
+
+    it('renders None for a missing tank', () => {
+      const group = new WoWGroup(null, healer, [dps1, dps2, dps3]);
+      expect(group.toTestString()).toBe(
+        'WoWGroup(Tank=None, Healer="Healer", DPS="DPS1", "DPS2", "DPS3(Brez)")',
+      );
+    });
+
+    it('renders None for a missing healer', () => {
+      const group = new WoWGroup(tank, null, [dps1, dps2, dps3]);
+      expect(group.toTestString()).toBe(
+        'WoWGroup(Tank="Tank", Healer=None, DPS="DPS1", "DPS2", "DPS3(Brez)")',
+      );
+    });
+
+    it('renders an empty DPS section as just the label and no players', () => {
+      const group = new WoWGroup(tank, healer, []);
+      expect(group.toTestString()).toBe(
+        'WoWGroup(Tank="Tank", Healer="Healer", DPS=)',
+      );
+    });
+
+    it('renders a fully-empty group', () => {
+      const group = new WoWGroup();
+      expect(group.toTestString()).toBe('WoWGroup(Tank=None, Healer=None, DPS=)');
+    });
+
+    it('renders utility annotations on tank and healer when present', () => {
+      const tankWithBrez = WoWPlayer.create('TankBrez', [ROLE_TANK, ROLE_BREZ]);
+      const healerWithLust = WoWPlayer.create('HealerLust', [ROLE_HEALER, ROLE_LUST]);
+      const group = new WoWGroup(tankWithBrez, healerWithLust, [lustPlayer]);
+      expect(group.toTestString()).toBe(
+        'WoWGroup(Tank="TankBrez(Brez)", Healer="HealerLust(Lust)", DPS="LustPlayer(Lust)")',
+      );
+    });
   });
 });

--- a/packages/shared/tests/dateHelpers.test.ts
+++ b/packages/shared/tests/dateHelpers.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { todayPST } from '../src/dateHelpers';
+
+describe('todayPST', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns the previous calendar date when UTC has rolled over but PST has not', () => {
+    // 03:00 UTC on 2026-04-07 is 20:00 (8pm) the previous day in PST/PDT.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-07T03:00:00Z'));
+    expect(todayPST()).toBe('2026-04-06');
+  });
+
+  it('returns the same calendar date when UTC and PST are aligned within the day', () => {
+    // 15:00 UTC on 2026-04-07 is 08:00 PDT same day.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-07T15:00:00Z'));
+    expect(todayPST()).toBe('2026-04-07');
+  });
+
+  it('formats the result as ISO YYYY-MM-DD', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T20:00:00Z'));
+    const result = todayPST();
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(result).toBe('2026-01-01');
+  });
+
+  it('handles winter PST (UTC-8) date crossover', () => {
+    // 07:00 UTC on 2026-01-15 is 23:00 PST the previous day.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-15T07:00:00Z'));
+    expect(todayPST()).toBe('2026-01-14');
+  });
+});

--- a/packages/shared/tests/types.test.ts
+++ b/packages/shared/tests/types.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { toRole, toUtility } from '../src/types';
+
+describe('toRole', () => {
+  it('returns each known role string verbatim', () => {
+    expect(toRole('tank')).toBe('tank');
+    expect(toRole('healer')).toBe('healer');
+    expect(toRole('ranged')).toBe('ranged');
+    expect(toRole('melee')).toBe('melee');
+  });
+
+  it('is case-sensitive — capitalized "Tank" is rejected', () => {
+    expect(toRole('Tank')).toBeNull();
+    expect(toRole('HEALER')).toBeNull();
+    expect(toRole('Ranged')).toBeNull();
+  });
+
+  it('rejects unknown role strings', () => {
+    expect(toRole('dps')).toBeNull();
+    expect(toRole('support')).toBeNull();
+    expect(toRole('')).toBeNull();
+    expect(toRole('tank ')).toBeNull(); // trailing space
+  });
+
+  it('returns null for non-string inputs', () => {
+    expect(toRole(42)).toBeNull();
+    expect(toRole(null)).toBeNull();
+    expect(toRole(undefined)).toBeNull();
+    expect(toRole({})).toBeNull();
+    expect(toRole([])).toBeNull();
+    expect(toRole(['tank'])).toBeNull();
+    expect(toRole(true)).toBeNull();
+    expect(toRole(false)).toBeNull();
+  });
+});
+
+describe('toUtility', () => {
+  it('returns each known utility string verbatim', () => {
+    expect(toUtility('brez')).toBe('brez');
+    expect(toUtility('lust')).toBe('lust');
+  });
+
+  it('is case-sensitive — uppercase "BREZ" is rejected', () => {
+    expect(toUtility('BREZ')).toBeNull();
+    expect(toUtility('Lust')).toBeNull();
+  });
+
+  it('rejects strings with whitespace', () => {
+    expect(toUtility('lust ')).toBeNull(); // trailing space
+    expect(toUtility(' brez')).toBeNull(); // leading space
+  });
+
+  it('rejects unknown utility strings', () => {
+    expect(toUtility('heroism')).toBeNull();
+    expect(toUtility('')).toBeNull();
+  });
+
+  it('returns null for non-string inputs', () => {
+    expect(toUtility(7)).toBeNull();
+    expect(toUtility(null)).toBeNull();
+    expect(toUtility(undefined)).toBeNull();
+    expect(toUtility({})).toBeNull();
+    expect(toUtility([])).toBeNull();
+    expect(toUtility(['brez'])).toBeNull();
+    expect(toUtility(true)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds unit tests for `toRole` and `toUtility` validators in `packages/shared/src/types.ts` (verbatim acceptance, case sensitivity, whitespace rejection, non-string inputs).
- Adds unit tests for `todayPST` in `packages/shared/src/dateHelpers.ts` using `vi.useFakeTimers` to fix UTC instants where the UTC and Pacific calendar dates differ (covering both PDT and PST).
- Extends `packages/bot/tests/models.test.ts` with coverage for `WoWPlayer.toTestString`, `WoWPlayer.toUtilitiesString`, and `WoWGroup.toTestString` (complete, missing tank/healer, empty DPS, fully-empty, utility-annotated cases).

## Test plan
- [x] `./scripts/verify-ts.sh` passes (lint + typecheck + 306 tests across bot + shared workspaces).
- [x] New `packages/shared/tests/types.test.ts` and `packages/shared/tests/dateHelpers.test.ts` run as part of the shared workspace's `vitest run`.
- [x] Extended `packages/bot/tests/models.test.ts` runs as part of the bot workspace's `vitest run`.

Generated by /overnight run 20260507-153155