### PR TITLE
refactor(bot): route storage/issues/debug/groupService errors through reportError

### DIFF
--- a/packages/bot/src/commands/debug.ts
+++ b/packages/bot/src/commands/debug.ts
@@ -1,5 +1,5 @@
 import type { GroupService, CommandContext } from '../services/groupService.js';
-import logger from '../core/logger.js';
+import { reportError } from '../core/sentry.js';
 
 export interface DebugContext extends CommandContext {
   channel: CommandContext['channel'] & {
@@ -19,7 +19,7 @@ export class DebugHandler {
       await this.groupService.coreWheel(ctx, true);
     } catch (e) {
       await ctx.send('❌ An unexpected error occurred. Please try again later.');
-      logger.error(`Error in test command: ${e}`);
+      reportError(e, { tags: { handler: 'debug.test' } });
     }
   }
 

--- a/packages/bot/src/core/issues.ts
+++ b/packages/bot/src/core/issues.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import * as config from './config.js';
 import logger from './logger.js';
+import { reportError } from './sentry.js';
 import { sanitizeForGithub, sanitizeLogs } from './security.js';
 
 export class GitHubError extends Error {
@@ -23,8 +24,7 @@ async function getRecentLogs(): Promise<string | null> {
       const lines = content.split('\n');
       return lines.slice(-50).join('\n');
     } catch (e) {
-      const errType = e instanceof Error ? e.constructor.name : String(e);
-      logger.error(`Failed to read logs: ${errType}`);
+      reportError(e, { tags: { handler: 'issues.getRecentLogs' } });
     }
   }
   return null;
@@ -94,7 +94,7 @@ export async function searchGithubIssues(
       }
     }
   } catch (e) {
-    logger.warn(`Failed to search for existing GitHub issues: ${e}`);
+    reportError(e, { tags: { handler: 'issues.searchGithubIssues' } });
   }
   return null;
 }
@@ -140,8 +140,7 @@ export async function createErrorIssue(
 
     return await createGithubIssue(title, body, ['bug', 'auto-error']);
   } catch (e) {
-    const errType = e instanceof Error ? e.constructor.name : String(e);
-    logger.error(`Failed to create automatic error issue: ${errType}`);
+    reportError(e, { tags: { handler: 'issues.createErrorIssue' } });
     return null;
   }
 }

--- a/packages/bot/src/core/storage.ts
+++ b/packages/bot/src/core/storage.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import logger from './logger.js';
+import { reportError } from './sentry.js';
 
 const PREFERENCES_PATH = process.env.PREFERENCES_PATH;
 const DATA_DIR = process.env.DATA_DIR;
@@ -20,8 +20,7 @@ function ensureLoaded(): void {
       const raw = fs.readFileSync(STORAGE_FILE, 'utf-8');
       preferencesCache = JSON.parse(raw) as Record<string, string[]>;
     } catch (e) {
-      const errType = e instanceof Error ? e.constructor.name : String(e);
-      logger.error(`Error loading preferences: ${errType}`);
+      reportError(e, { tags: { handler: 'storage.loadPreferences' } });
       preferencesCache = {};
     }
   } else {
@@ -39,8 +38,7 @@ export function savePreferences(preferences: Record<string, string[]>): void {
     preferencesCache = preferences;
     fs.writeFileSync(STORAGE_FILE, JSON.stringify(preferences, null, 4));
   } catch (e) {
-    const errType = e instanceof Error ? e.constructor.name : String(e);
-    logger.error(`Error saving preferences: ${errType}`);
+    reportError(e, { tags: { handler: 'storage.savePreferences' } });
   }
 }
 

--- a/packages/bot/src/services/groupService.ts
+++ b/packages/bot/src/services/groupService.ts
@@ -10,7 +10,7 @@ import { announceGroup, type Sendable } from '../core/groupUi.js';
 import { getPlayerList, type DiscordMember, type TypingChannel } from '../core/utils.js';
 import { getDebugPlayers } from '../core/debugFixtures.js';
 import { FirebaseService } from '../core/firebaseService.js';
-import logger from '../core/logger.js';
+import { reportError } from '../core/sentry.js';
 
 export interface CommandContext extends Sendable {
   channel: { members: DiscordMember[] } & TypingChannel;
@@ -81,7 +81,10 @@ export class GroupService {
       );
       setGroupHistory(rounds, guildId);
     } catch (err) {
-      logger.warn(`Failed to load group history for guild ${guildId}: ${err}`);
+      reportError(err, {
+        tags: { handler: 'groupService.loadGroupHistory' },
+        extra: { guildId },
+      });
     }
   }
 
@@ -106,7 +109,10 @@ export class GroupService {
         await this._bumpSeasonPairs(firebase, guildId, groups);
       }
     } catch (err) {
-      logger.warn(`Failed to save group history for guild ${guildId}: ${err}`);
+      reportError(err, {
+        tags: { handler: 'groupService.saveGroupHistory' },
+        extra: { guildId },
+      });
     } finally {
       this.loadedRounds.delete(guildId);
     }

--- a/packages/bot/tests/debugCommand.test.ts
+++ b/packages/bot/tests/debugCommand.test.ts
@@ -58,7 +58,7 @@ describe('DebugHandler.test', () => {
     await handler.test(ctx);
 
     expect(ctx.send).toHaveBeenCalledWith('❌ An unexpected error occurred. Please try again later.');
-    expect(logger.error).toHaveBeenCalledWith('Error in test command: Error: Test error');
+    expect(logger.error).toHaveBeenCalledWith('[debug.test] Error: Test error');
   });
 });
 


### PR DESCRIPTION
## Summary

Replace the legacy `errType = e instanceof Error ? e.constructor.name : String(e)` + `logger.error/warn(...)` pattern with `reportError(e, { tags: { handler: '...' } })` in four bot files. These hot paths (preference load/save, GitHub issue creation, group history persistence, debug command) were silently swallowing exceptions in Sentry by bypassing the unified error-reporting entrypoint.

## Files touched

- `packages/bot/src/core/storage.ts` — `loadPreferences`, `savePreferences`
- `packages/bot/src/core/issues.ts` — `getRecentLogs`, `searchGithubIssues`, `createErrorIssue`
- `packages/bot/src/services/groupService.ts` — `_loadGroupHistory`, `_saveGroupHistory` (both now include `extra: { guildId }`)
- `packages/bot/src/commands/debug.ts` — `test` command
- `packages/bot/tests/debugCommand.test.ts` — updated assertion to match `reportError`'s `[handler] ${err}` log format

## Test plan

- [x] `./scripts/verify-ts.sh` passes (lint + typecheck + tests across shared/bot)
- [x] No `errType` references remain in the touched files (only `core/firebaseService.ts` retains the legacy pattern, out of scope)
- [x] `debugCommand.test.ts` updated to match new log format and still passes

Generated by /overnight run 20260507-153155