### PR TITLE
refactor(bot): extract adaptGuild + buildVoiceChannelsSnapshot helpers

### DIFF
--- a/packages/bot/src/core/discordAdapters.ts
+++ b/packages/bot/src/core/discordAdapters.ts
@@ -1,0 +1,83 @@
+import type { Guild as DjsGuild, VoiceChannel as DjsVoiceChannel } from 'discord.js';
+import type { Guild, VoiceChannel } from '../services/sessionService.js';
+
+/**
+ * Lightweight voice-channel summary written to the activity Firestore guild
+ * doc. The activity frontend reads `voiceChannels` to render the channel list.
+ */
+export interface VoiceChannelSnapshot {
+  id: string;
+  name: string;
+  userCount: number;
+}
+
+/**
+ * Minimal shape needed to compute a voice channel snapshot.
+ * Both the adapter `VoiceChannel` and a freshly-adapted discord.js voice
+ * channel satisfy this.
+ */
+interface VoiceChannelLike {
+  id: string;
+  name: string;
+  members: ReadonlyArray<{ bot: boolean }>;
+}
+
+/**
+ * Build the `{id, name, userCount}` snapshot list used by the activity
+ * frontend. `userCount` excludes bots.
+ *
+ * When `sorted` is true (the default for the activity flow), channels are
+ * sorted by userCount desc, then alphabetically by name. This matches the
+ * behavior previously inlined at main.ts (guild refresh listener) and
+ * sessionService.refreshGuildVoiceChannels.
+ */
+export function buildVoiceChannelsSnapshot(
+  channels: Iterable<VoiceChannelLike>,
+  options: { sorted?: boolean } = {},
+): VoiceChannelSnapshot[] {
+  const out: VoiceChannelSnapshot[] = [];
+  for (const ch of channels) {
+    const userCount = [...ch.members].filter((m) => !m.bot).length;
+    out.push({ id: ch.id, name: ch.name, userCount });
+  }
+  if (options.sorted) {
+    out.sort((a, b) => {
+      if (b.userCount !== a.userCount) return b.userCount - a.userCount;
+      return a.name.localeCompare(b.name);
+    });
+  }
+  return out;
+}
+
+/**
+ * Convert a discord.js Guild to the adapter `Guild` shape used by handler
+ * code (sessionService, groups command, etc.).
+ *
+ * `voice_channels` is exposed via a getter so the discord.js channels cache
+ * is read lazily — the adapter stays in sync with cache mutations between
+ * the time the adapter is built and the time it's actually iterated. This
+ * lazy-getter pattern was previously inlined at three sites in main.ts;
+ * keeping it preserves the original semantics.
+ */
+export function adaptGuild(
+  djsGuild: DjsGuild | null,
+  adaptVoiceChannel: (ch: DjsVoiceChannel) => VoiceChannel,
+): Guild | null {
+  if (!djsGuild) return null;
+  const iconUrl = djsGuild.iconURL();
+  return {
+    id: djsGuild.id,
+    name: djsGuild.name,
+    icon: iconUrl ? { url: iconUrl } : null,
+    get voice_channels(): VoiceChannel[] {
+      return djsGuild.channels.cache
+        .filter((ch) => ch.isVoiceBased())
+        .map((ch) => adaptVoiceChannel(ch as unknown as DjsVoiceChannel));
+    },
+    get_channel(chId: string): VoiceChannel | null {
+      const ch = djsGuild.channels.cache.get(chId);
+      if (!ch || !ch.isVoiceBased()) return null;
+      return adaptVoiceChannel(ch as unknown as DjsVoiceChannel);
+    },
+  };
+}

--- a/packages/bot/src/main.ts
+++ b/packages/bot/src/main.ts
@@ -26,6 +26,7 @@ import * as config from './core/config.js';
 import logger from './core/logger.js';
 import { GroupService } from './services/groupService.js';
 import { SessionService, type Bot, type Guild, type VoiceChannel } from './services/sessionService.js';
+import { adaptGuild, buildVoiceChannelsSnapshot } from './core/discordAdapters.js';
 import { GeneralHandler } from './commands/general.js';
 import { GroupsHandler } from './commands/groups.js';
 import { DebugHandler } from './commands/debug.js';
@@ -119,23 +120,7 @@ function createBotAdapter(client: Client): Bot {
   return {
     get_guild(id: string): Guild | null {
       const g = client.guilds.cache.get(id);
-      if (!g) return null;
-      const guildIcon = g.iconURL();
-      return {
-        id: g.id,
-        name: g.name,
-        icon: guildIcon ? { url: guildIcon } : null,
-        get voice_channels(): VoiceChannel[] {
-          return g.channels.cache
-            .filter((ch) => ch.isVoiceBased())
-            .map((ch) => adaptVoiceChannel(ch as unknown as import('discord.js').VoiceChannel));
-        },
-        get_channel(chId: string): VoiceChannel | null {
-          const ch = g.channels.cache.get(chId);
-          if (!ch || !ch.isVoiceBased()) return null;
-          return adaptVoiceChannel(ch as unknown as import('discord.js').VoiceChannel);
-        },
-      };
+      return adaptGuild(g ?? null, adaptVoiceChannel);
     },
   };
 }
@@ -539,17 +524,12 @@ async function main() {
         const guildName = discordGuild.name;
         const guildIconUrl = discordGuild.iconURL();
 
-        const voiceChannelsData = discordGuild.channels.cache
-          .filter((ch) => ch.isVoiceBased())
-          .map((ch) => {
-            const vc = ch as import('discord.js').VoiceChannel;
-            const count = vc.members.map((m) => adaptMember(m)).filter((m) => !m.bot).length;
-            return { id: ch.id, name: ch.name, userCount: count };
-          })
-          .sort((a, b) => {
-            if (b.userCount !== a.userCount) return b.userCount - a.userCount;
-            return a.name.localeCompare(b.name);
-          });
+        const voiceChannelsData = buildVoiceChannelsSnapshot(
+          discordGuild.channels.cache
+            .filter((ch) => ch.isVoiceBased())
+            .map((ch) => adaptVoiceChannel(ch as import('discord.js').VoiceChannel)),
+          { sorted: true },
+        );
 
         const updateData: Record<string, unknown> = {
           voiceChannels: voiceChannelsData,
@@ -755,24 +735,8 @@ async function main() {
 
       case 'wheelson': {
         const voiceChannel = member?.voice.channel;
-        // activity's getOrCreateSession needs extra guild fields; cast to satisfy handler
-        const djsGuild = interaction.guild;
-        const activityIconUrl = djsGuild?.iconURL();
-        const activityGuild = djsGuild
-          ? {
-              id: djsGuild.id,
-              name: djsGuild.name,
-              icon: activityIconUrl ? { url: activityIconUrl } : null,
-              voice_channels: djsGuild.channels.cache
-                .filter((ch) => ch.isVoiceBased())
-                .map((ch) => adaptVoiceChannel(ch as import('discord.js').VoiceChannel)),
-              get_channel(chId: string): VoiceChannel | null {
-                const ch = djsGuild.channels.cache.get(chId);
-                if (!ch || !ch.isVoiceBased()) return null;
-                return adaptVoiceChannel(ch as import('discord.js').VoiceChannel);
-              },
-            }
-          : null;
+        // activity's getOrCreateSession needs the adapter Guild shape
+        const activityGuild = adaptGuild(interaction.guild, adaptVoiceChannel);
         await groupsHandler.activity(
           {
             guild: activityGuild,
@@ -1287,23 +1251,8 @@ async function main() {
       const member = newState.member ?? oldState.member;
       if (!member) return;
 
-      const guild = member.guild;
-      const voiceGuildIcon = guild.iconURL();
-      const guildAdapter: Guild = {
-        id: guild.id,
-        name: guild.name,
-        icon: voiceGuildIcon ? { url: voiceGuildIcon } : null,
-        get voice_channels() {
-          return guild.channels.cache
-            .filter((ch) => ch.isVoiceBased())
-            .map((ch) => adaptVoiceChannel(ch as import('discord.js').VoiceChannel));
-        },
-        get_channel(chId: string) {
-          const ch = guild.channels.cache.get(chId);
-          if (!ch || !ch.isVoiceBased()) return null;
-          return adaptVoiceChannel(ch as import('discord.js').VoiceChannel);
-        },
-      };
+      const guildAdapter = adaptGuild(member.guild, adaptVoiceChannel);
+      if (!guildAdapter) return;
 
       const before = {
         channel: oldState.channel

--- a/packages/bot/src/services/sessionService.ts
+++ b/packages/bot/src/services/sessionService.ts
@@ -1,6 +1,7 @@
 import { FirebaseService, ARRAY_UNION, ARRAY_REMOVE } from '../core/firebaseService.js';
 import logger from '../core/logger.js';
 import { getPlayerList, type DiscordMember } from '../core/utils.js';
+import { buildVoiceChannelsSnapshot } from '../core/discordAdapters.js';
 
 export interface ActiveChannel {
   docId: string;
@@ -129,19 +130,8 @@ export class SessionService {
   }
 
   async refreshGuildVoiceChannels(guild: Guild): Promise<void> {
-    const voiceChannelsData: { id: string; name: string; userCount: number }[] = [];
-    for (const vc of guild.voice_channels) {
-      const count = vc.members.filter((m) => !m.bot).length;
-      voiceChannelsData.push({
-        id: vc.id,
-        name: vc.name,
-        userCount: count,
-      });
-    }
-
-    voiceChannelsData.sort((a, b) => {
-      if (b.userCount !== a.userCount) return b.userCount - a.userCount;
-      return a.name.localeCompare(b.name);
+    const voiceChannelsData = buildVoiceChannelsSnapshot(guild.voice_channels, {
+      sorted: true,
     });
 
     await this.firebase.updateGuildDoc(guild.id, {


### PR DESCRIPTION
## Summary

Deduplicates 5 inline implementations of discord.js Guild → adapter conversion and voice-channel snapshot construction into a new `packages/bot/src/core/discordAdapters.ts` module.

**Helpers added:**
- `adaptGuild(djsGuild, adaptVoiceChannel)` — produces the adapter `Guild` shape (id/name/icon, lazy `voice_channels` getter, `get_channel`)
- `buildVoiceChannelsSnapshot(channels, { sorted? })` — produces `{id, name, userCount}[]` for the activity Firestore guild doc; excludes bots from `userCount`

**Call sites collapsed:**
- `main.ts` `createBotAdapter` (lazy voice_channels getter)
- `main.ts` guild refresh Firestore listener
- `main.ts` `/wheelson` handler (was eager — now lazy via the helper)
- `main.ts` `voiceStateUpdate` handler (lazy voice_channels getter)
- `sessionService.refreshGuildVoiceChannels` (snapshot for Firestore)

The lazy-getter pattern on `voice_channels` is preserved so the live discord.js cache is read on access, matching prior semantics. Bot-filter semantics for `userCount` also match: the original code computed `adaptMember(m).bot` which equals `m.user.bot`; the helper accepts the already-adapted `VoiceChannel.members` shape (`{bot: boolean}[]`).

Net: ~60 lines removed from `main.ts`, ~10 lines removed from `sessionService.ts`, +95 lines in the new helper module (much of it doc comments).

## Test plan

- [x] `./scripts/verify-ts.sh` passes (lint + typecheck + 286 tests)
- [x] Existing `sessionService.refreshGuildVoiceChannels` tests still pass — they exercise the abstract `Guild` interface and now indirectly cover `buildVoiceChannelsSnapshot`
- [ ] Manual smoke test of `/wheelson` and `/activity` flows in a Discord server (relies on Firebase + voice channel state)

Generated by /overnight run 20260507-153155