### PR TITLE
refactor(activity): move dungeon score types to lib layer

### DIFF
--- a/activity/src/components/GroupCarousel.tsx
+++ b/activity/src/components/GroupCarousel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { GroupSlide } from './GroupSlide';
 import type { WoWGroup } from '../types';
-import type { CharacterDungeonScores } from '../services/raiderioMythicPlus';
+import type { CharacterDungeonScores } from '../lib/dungeonScoreTypes';
 
 const SWIPE_THRESHOLD_PX = 40;
 

--- a/activity/src/components/GroupSlide.tsx
+++ b/activity/src/components/GroupSlide.tsx
@@ -1,5 +1,5 @@
 import type { WoWGroup, WoWPlayer } from '../types';
-import type { CharacterDungeonScores } from '../services/raiderioMythicPlus';
+import type { CharacterDungeonScores } from '../lib/dungeonScoreTypes';
 import { utilityIcons } from '../lib/roles';
 import { SpotlightPortrait } from './SpotlightPortrait';
 import { useState } from 'react';

--- a/activity/src/components/SpotlightPortrait.stories.tsx
+++ b/activity/src/components/SpotlightPortrait.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { CHARACTER_CLASSES } from '@mythicplus/shared';
 import { SpotlightPortrait } from './SpotlightPortrait';
-import type { CharacterDungeonScores } from '../services/raiderioMythicPlus';
+import type { CharacterDungeonScores } from '../lib/dungeonScoreTypes';
 
 // Realistic-looking sample so the hover/focus tooltip has something to show.
 // Edit `name`, `score`, `level`, and `iconUrl` here to preview different

--- a/activity/src/components/SpotlightPortrait.tsx
+++ b/activity/src/components/SpotlightPortrait.tsx
@@ -14,7 +14,7 @@ import {
   useTransitionStyles,
 } from '@floating-ui/react';
 import type { CharacterClass } from '@mythicplus/shared';
-import type { CharacterDungeonScores } from '../services/raiderioMythicPlus';
+import type { CharacterDungeonScores } from '../lib/dungeonScoreTypes';
 import { remapImageUrl } from '../discordSdk';
 import { toMainBodyUrl } from '../lib/characterMedia';
 import { getClassColor } from '../lib/classColors';

--- a/activity/src/components/SpotlightPortraits.tsx
+++ b/activity/src/components/SpotlightPortraits.tsx
@@ -1,5 +1,5 @@
 import { WoWPlayer } from '../types';
-import type { CharacterDungeonScores } from '../services/raiderioMythicPlus';
+import type { CharacterDungeonScores } from '../lib/dungeonScoreTypes';
 import { SpotlightPortrait } from './SpotlightPortrait';
 
 interface SpotlightPortraitsProps {

--- a/activity/src/hooks/useDungeonSuggestions.ts
+++ b/activity/src/hooks/useDungeonSuggestions.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useAppStore } from '../store/store';
 import { fetchCharacterDungeonScores } from '../services/raiderioMythicPlus';
-import type { CharacterDungeonScores } from '../services/raiderioMythicPlus';
+import type { CharacterDungeonScores } from '../lib/dungeonScoreTypes';
 import { computeDungeonRanking } from '../lib/dungeonSuggestions';
 import type { DungeonSuggestionsState } from '../lib/dungeonSuggestions';
 import type { WoWPlayer } from '../types';

--- a/activity/src/lib/dungeonScoreTypes.ts
+++ b/activity/src/lib/dungeonScoreTypes.ts
@@ -1,0 +1,36 @@
+// Type contracts for Raider.io per-character dungeon score data.
+//
+// Lives in `lib/` so both the I/O boundary (`services/raiderioMythicPlus.ts`)
+// and pure consumers (`lib/dungeonSuggestions.ts`, components, hooks) can
+// import the shapes without `lib/` depending on `services/`.
+
+export interface DungeonRunSummary {
+  /** Stable identifier (challenge_mode_id) for matching across runs and seasons. */
+  challengeModeId: number;
+  /** Display name (e.g. "Operation: Floodgate"). */
+  name: string;
+  /** Short tag (e.g. "FLOOD"). */
+  shortName: string;
+  /** Best key level the character has timed/run for this dungeon, or 0. */
+  level: number;
+  /** Raider.io score for the best run, or 0. */
+  score: number;
+  /** Dungeon icon URL from Raider.io's CDN, or null when missing. */
+  iconUrl: string | null;
+}
+
+export interface CharacterDungeonScores {
+  name: string;
+  realm: string;
+  region: string;
+  /** Best run per dungeon, keyed by challenge_mode_id. */
+  byDungeon: Record<number, DungeonRunSummary>;
+  /** Overall Raider.io M+ score for the current season ("all" segment), or null. */
+  overallScore: number | null;
+  /** Raider.io rarity color for the overall score (e.g. "#f06862"), or null. */
+  scoreColor: string | null;
+  /** Character's class name from Raider.io (e.g. "Mage"), or null. */
+  className: string | null;
+  /** Active spec name (e.g. "Frost"), or null. */
+  specName: string | null;
+}

--- a/activity/src/lib/dungeonSuggestions.test.ts
+++ b/activity/src/lib/dungeonSuggestions.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { computeDungeonRanking } from './dungeonSuggestions';
-import type { CharacterDungeonScores } from '../services/raiderioMythicPlus';
+import type { CharacterDungeonScores } from './dungeonScoreTypes';
 
 function makeChar(
   name: string,

--- a/activity/src/lib/dungeonSuggestions.ts
+++ b/activity/src/lib/dungeonSuggestions.ts
@@ -1,4 +1,4 @@
-import type { CharacterDungeonScores, DungeonRunSummary } from '../services/raiderioMythicPlus';
+import type { CharacterDungeonScores, DungeonRunSummary } from './dungeonScoreTypes';
 
 export type DungeonSuggestionsStatus = 'idle' | 'loading' | 'ready' | 'empty' | 'error';
 

--- a/activity/src/services/raiderioMythicPlus.ts
+++ b/activity/src/services/raiderioMythicPlus.ts
@@ -1,36 +1,11 @@
 // Public Raider.io endpoints — same hostname/contract used by `lookupCharacterProfile`.
 // CORS is enabled, so we can call directly from the browser.
 
-export interface DungeonRunSummary {
-  /** Stable identifier (challenge_mode_id) for matching across runs and seasons. */
-  challengeModeId: number;
-  /** Display name (e.g. "Operation: Floodgate"). */
-  name: string;
-  /** Short tag (e.g. "FLOOD"). */
-  shortName: string;
-  /** Best key level the character has timed/run for this dungeon, or 0. */
-  level: number;
-  /** Raider.io score for the best run, or 0. */
-  score: number;
-  /** Dungeon icon URL from Raider.io's CDN, or null when missing. */
-  iconUrl: string | null;
-}
+import type { CharacterDungeonScores, DungeonRunSummary } from '../lib/dungeonScoreTypes';
 
-export interface CharacterDungeonScores {
-  name: string;
-  realm: string;
-  region: string;
-  /** Best run per dungeon, keyed by challenge_mode_id. */
-  byDungeon: Record<number, DungeonRunSummary>;
-  /** Overall Raider.io M+ score for the current season ("all" segment), or null. */
-  overallScore: number | null;
-  /** Raider.io rarity color for the overall score (e.g. "#f06862"), or null. */
-  scoreColor: string | null;
-  /** Character's class name from Raider.io (e.g. "Mage"), or null. */
-  className: string | null;
-  /** Active spec name (e.g. "Frost"), or null. */
-  specName: string | null;
-}
+// Re-export the type contracts so existing consumers that import from this
+// module keep working. The canonical home for the types is `lib/dungeonScoreTypes`.
+export type { CharacterDungeonScores, DungeonRunSummary } from '../lib/dungeonScoreTypes';
 
 interface RaiderioRun {
   dungeon: string;


### PR DESCRIPTION
## Summary

- Moves `CharacterDungeonScores` and `DungeonRunSummary` interfaces from `services/raiderioMythicPlus.ts` to a new `lib/dungeonScoreTypes.ts`, fixing a `lib`→`services` layer violation in `lib/dungeonSuggestions.ts`.
- `services/raiderioMythicPlus.ts` re-exports the types from the new location so any external consumer importing from there keeps working — pure backward-compatible refactor.
- Updates 8 consumer files to import directly from `lib/dungeonScoreTypes`.

## Why

The architecture convention is `services/` (the I/O boundary) depends on `lib/` (pure logic), not the other way around. `lib/dungeonSuggestions.ts` was importing types from `services/raiderioMythicPlus.ts`, which inverted that dependency. Several components and a hook also imported the types from the services file, meaning the type contract was effectively owned by an I/O module.

Moving the types to `lib/dungeonScoreTypes.ts` makes the canonical home a pure-type module that both the I/O module and pure consumers can depend on.

## Test plan

- [x] `./scripts/verify-ts.sh` passes (lint + typecheck + tests)
- [x] `cd activity && npm run build` succeeds
- [x] `cd activity && npm run typecheck` introduces zero new errors (105 pre-existing on main → 105 on this branch)
- [x] No runtime change — pure type-only move with re-export for backward compat

Generated by /overnight run 20260507-153155