### PR TITLE
refactor(shared): extract parseSeasonPairs validator

### DIFF
--- a/activity/src/services/firestoreService.ts
+++ b/activity/src/services/firestoreService.ts
@@ -9,6 +9,7 @@ import {
   createMythicPlusGroups,
   decodeGroupHistoryRounds,
   encodeGroupHistoryRounds,
+  parseSeasonPairs,
   setGroupHistory,
   todayPST,
 } from '@mythicplus/shared';
@@ -104,20 +105,7 @@ class FirestoreSessionService implements SessionService {
         if (docSnap.exists()) {
           const data = docSnap.data() as GuildData;
           s.setGuildData(data);
-          const sp = data.seasonPairs;
-          if (
-            sp &&
-            typeof sp.seasonSlug === 'string' &&
-            typeof sp.counts === 'object' &&
-            sp.counts !== null
-          ) {
-            s.setSeasonPairs({
-              seasonSlug: sp.seasonSlug,
-              counts: sp.counts as Record<string, number>,
-            });
-          } else {
-            s.setSeasonPairs(null);
-          }
+          s.setSeasonPairs(parseSeasonPairs(data.seasonPairs));
           s.setStatusMessage('');
           return;
         }

--- a/packages/bot/src/core/firebaseService.ts
+++ b/packages/bot/src/core/firebaseService.ts
@@ -2,6 +2,7 @@ import { createRequire } from 'node:module';
 import {
   decodeGroupHistoryRounds,
   encodeGroupHistoryRounds,
+  parseSeasonPairs,
   type WoWGroupDict,
 } from '@mythicplus/shared';
 import logger from './logger.js';
@@ -400,19 +401,7 @@ export class FirebaseService implements IFirebaseService {
     const doc = await docRef.get();
     if (!doc.exists) return null;
     const data = doc.data() ?? {};
-    const sp = data.seasonPairs as { seasonSlug?: unknown; counts?: unknown } | undefined;
-    if (
-      !sp ||
-      typeof sp.seasonSlug !== 'string' ||
-      typeof sp.counts !== 'object' ||
-      sp.counts === null
-    ) {
-      return null;
-    }
-    return {
-      seasonSlug: sp.seasonSlug,
-      counts: sp.counts as Record<string, number>,
-    };
+    return parseSeasonPairs(data.seasonPairs);
   }
 
   async saveSeasonPairs(

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -26,6 +26,7 @@ export {
   bumpPairCounts,
   topAffinityFor,
   shortestPath,
+  parseSeasonPairs,
 } from './seasonPairs.js';
 
 export { generateInviteCommand } from './inviteCommand.js';

--- a/packages/shared/src/seasonPairs.ts
+++ b/packages/shared/src/seasonPairs.ts
@@ -12,6 +12,20 @@ export interface SeasonPairs {
 }
 
 /**
+ * Validate an unknown value against the {@link SeasonPairs} shape. Returns the
+ * narrowed object when valid (string `seasonSlug`, non-null object `counts`)
+ * and `null` otherwise. The bot and frontend both run this on raw Firestore
+ * values, so they must not drift on what "valid" means.
+ */
+export function parseSeasonPairs(raw: unknown): SeasonPairs | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const sp = raw as { seasonSlug?: unknown; counts?: unknown };
+  if (typeof sp.seasonSlug !== 'string') return null;
+  if (typeof sp.counts !== 'object' || sp.counts === null) return null;
+  return { seasonSlug: sp.seasonSlug, counts: sp.counts as Record<string, number> };
+}
+
+/**
  * Increment season pair counts by every pair in `round`. Returns a NEW map;
  * does not mutate `current`. Groups with fewer than 2 players are skipped
  * (degenerate remainders).


### PR DESCRIPTION
## Summary

The same `seasonPairs` shape validator was duplicated inline in two places:
- `packages/bot/src/core/firebaseService.ts::getSeasonPairs`
- `activity/src/services/firestoreService.ts::subscribeToGuild` (onSnapshot callback)

Both checked `seasonSlug: string` + non-null object `counts`. Future tightening of the type boundary (e.g., per-value validation) would otherwise need to be applied in two places.

This adds `parseSeasonPairs(raw: unknown): SeasonPairs | null` to `packages/shared/src/seasonPairs.ts`, re-exports from `index.ts`, and replaces both inline checks. Runtime behavior is identical; both consumers still gracefully handle a `null` return.

## Test plan

- [x] `./scripts/verify-ts.sh` passes (lint + typecheck + tests)
- [x] No behavior change — both call sites already handled `null`

Generated by /overnight run 20260507-153155